### PR TITLE
clear cart on logout

### DIFF
--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -11,6 +11,7 @@ import { AuthRedirect } from "@/components/Auth/AuthRedirect";
 import { clearCachedAuthToken } from "@/api/axios";
 import { toast } from "sonner";
 import { AuthService } from "@/api/services/auth";
+import { clearCart } from "@/store/slices/cartSlice";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
@@ -248,6 +249,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       // 2. Clear Redux store data
       dispatch(resetRoles());
       dispatch(clearSelectedUser());
+      dispatch(clearCart());
 
       // 3. Clear all browser storage comprehensively
       localStorage.clear();
@@ -318,6 +320,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       // Even if there's an error, still clear local data and navigate
       dispatch(resetRoles());
       dispatch(clearSelectedUser());
+      dispatch(clearCart());
       localStorage.clear();
       sessionStorage.clear();
       setSession(null);


### PR DESCRIPTION
This pull request enhances the logout process in the `AuthProvider` by ensuring that the user's cart is also cleared from the Redux store when logging out. This helps prevent stale or unauthorized cart data from persisting after a user session ends.

Previously we saved cart only in Redux, so if you loggedin with another user or closed browser tab, cart would be replaced anyway.

**Improvements to logout data clearing:**

* Added import for `clearCart` from `cartSlice` and updated the logout logic to dispatch `clearCart()` alongside other store resets, ensuring the cart state is cleared on logout. [[1]](diffhunk://#diff-c5988b94ea3fc5586a8fdad872627efca79041edf7d4b4171e4e949086ee05c5R14) [[2]](diffhunk://#diff-c5988b94ea3fc5586a8fdad872627efca79041edf7d4b4171e4e949086ee05c5R252) [[3]](diffhunk://#diff-c5988b94ea3fc5586a8fdad872627efca79041edf7d4b4171e4e949086ee05c5R323)