### PR TITLE
add storage_manager to allowedRoles in router

### DIFF
--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -241,7 +241,9 @@ export const router = createBrowserRouter([
           {
             path: "categories",
             element: (
-              <ProtectedRoute allowedRoles={["tenant_admin"]}>
+              <ProtectedRoute
+                allowedRoles={["tenant_admin", "storage_manager"]}
+              >
                 <Categories />
               </ProtectedRoute>
             ),
@@ -249,7 +251,9 @@ export const router = createBrowserRouter([
           {
             path: "categories/:id",
             element: (
-              <ProtectedRoute allowedRoles={["tenant_admin"]}>
+              <ProtectedRoute
+                allowedRoles={["tenant_admin", "storage_manager"]}
+              >
                 <AddCategory />
               </ProtectedRoute>
             ),


### PR DESCRIPTION
Added storage_manager to allowedRoles in the router so that they could actually see/add categories. So far they only saw the tab (and an empty page)