### PR TITLE
add an example of the contents of the translations modules

### DIFF
--- a/docs/developers/frontend/translation.md
+++ b/docs/developers/frontend/translation.md
@@ -8,9 +8,9 @@ This project supports full English and Finnish localization for all user-facing 
 [Database Translations](#2-database-translations)  
 [How DB translations are used in the frontend](#how-db-translations-are-used-in-the-frontend)  
 [Usage](#3-usage-in-components)  
-[Naming conventions](#4b-naming-conventions)  
 [Adding translations](#4-adding-translations)  
-[Checking coverage](#5-checking-coverage)
+[Naming conventions](#5-naming-conventions)  
+[Checking coverage](#6-checking-coverage)
 
 ## 1. Frontend Translations
 
@@ -97,16 +97,101 @@ See [docs/developers/backend/database-schema.md](docs/developers/backend/databas
 ## 4. Adding Translations
 
 1. Add new keys to the relevant module file in [frontend/src/translations/modules/](frontend/src/translations/modules/).
-2. Provide both Finnish (`fi`) and English (`en`) values.
+2. Provide key/value pairs for all supported languages
 3. Import the module in [frontend/src/translations/index.ts](frontend/src/translations/index.ts).
 
-## 4b. Naming Conventions
+## 5. Naming Conventions
 
+### File naming
 Each new file should have its own translation module. The module should have the same naming as the file which uses it, but in camelCase
 
-Therefor the translation module for a file called `ItemModal.tsx` would be called -> `itemModal.ts`
+**Example:** The translations for a file called `ItemModal.tsx` would be called -> `itemModal.ts`
 
-## 5. Checking Coverage
+### Content Structure
+The namings of the key/value pairs should ideally be after the contents of the page, for example all buttons should be under the same "buttons" key, or "labels" for labels, "placeholders" for placeholders, etc.
+```ts
+// Example
+export const addCategory = {
+  headings: {
+    addNew: {
+      en: "Add Category",
+      fi: "Lisää kategoria",
+    },
+    update: {
+      en: "Update Category",
+      fi: "Päivitä kategoria",
+    },
+  },
+  form: {
+    nameFi: {
+      en: "Name (fi)",
+      fi: "Nimi (fi)",
+    },
+    nameEn: {
+      en: "Name (en)",
+      fi: "Nimi (en)",
+    },
+    parentCategory: {
+      en: "Parent Category",
+      fi: "Yläkategoria",
+    },
+  },
+  messages: {
+    update: {
+      fail: {
+        fi: "Kategorian päivitys epäonnistui",
+        en: "Failed to update category",
+      },
+      success: {
+        en: "Category was updated!",
+        fi: "Kategoria päivitetty!",
+      },
+    },
+    create: {
+      fail: {
+        en: "Failed to create category",
+        fi: "Kategorian luominen epäonnistui",
+      },
+      success: {
+        en: "Category was created!",
+        fi: "Kategoria luotu!",
+      },
+    },
+    general: {
+      fi: "Jotain meni pieleen. Yritä uudelleen myöhemmin tai ota yhteyttä tukeen.",
+      en: "Something went wrong. Try again later or contact support",
+    },
+    loading: {
+      en: "Loading...",
+      fi: "Ladataan...",
+    },
+  },
+  buttons: {
+    cancel: {
+      fi: "Peruuta",
+      en: "Cancel",
+    },
+    back: {
+      fi: "Peruuta",
+      en: "Back",
+    },
+    save: {
+      fi: "Tallenna",
+      en: "Save",
+    },
+  },
+  placeholders: {
+    noParent: {
+      en: "No parent",
+      fi: "Ei yläkategoriaa",
+    },
+  },
+};
+
+```
+
+
+## 6. Checking Coverage
 
 Run the translation checker script to ensure all UI strings are properly translated and highlight any hardcoded text that should be moved to translation files.
 

--- a/docs/developers/frontend/translation.md
+++ b/docs/developers/frontend/translation.md
@@ -103,12 +103,15 @@ See [docs/developers/backend/database-schema.md](docs/developers/backend/databas
 ## 5. Naming Conventions
 
 ### File naming
+
 Each new file should have its own translation module. The module should have the same naming as the file which uses it, but in camelCase
 
 **Example:** The translations for a file called `ItemModal.tsx` would be called -> `itemModal.ts`
 
 ### Content Structure
+
 The namings of the key/value pairs should ideally be after the contents of the page, for example all buttons should be under the same "buttons" key, or "labels" for labels, "placeholders" for placeholders, etc.
+
 ```ts
 // Example
 export const addCategory = {
@@ -187,9 +190,77 @@ export const addCategory = {
     },
   },
 };
-
 ```
 
+## 6. Adding a new language
+
+To make it easier to add new languages, we've created a `SUPPORTED_LANGUAGES` variable containing the relevant country details.
+Each language requires:
+
+1. **lang**: English name of the language for easy identification
+2. **key**: language code ([See list of language codes here](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes))
+3. **translations** ([see below](#translations))
+
+```ts
+import { supportedLanguages } from "@/translations/modules/supportedLanguages";
+
+export const SUPPORTED_LANGUAGES = [
+  {
+    lang: "English",
+    key: "en",
+    translations: supportedLanguages.en,
+  },
+  {
+    lang: "Finnish",
+    key: "fi",
+    translations: supportedLanguages.fi,
+  },
+  // New language example
+  {
+    lang: "Swedish",
+    key: "sv",
+    translations: supportedLanguages.sv,
+  },
+];
+```
+
+### Translations
+
+Add the language translations as the following. **Each language must have a corresponding translation in **ALL** other represented languages**
+
+```ts
+// Language Translations
+export const supportedLanguages = {
+  en: {
+    en: "English",
+    fi: "Englanti",
+    sv: "Engelska",
+  },
+  fi: {
+    en: "Finnish",
+    fi: "Suomi",
+    sv: "Finska",
+  },
+  sv: {
+    en: "Swedish",
+    fi: "Ruotsi",
+    sv: "Svenska",
+  },
+};
+```
+
+### Update the types
+
+Finally, update the `Language` type in the [LanguageContext](frontend/src/context/LanguageContext.tsx) with the newly added key
+
+```ts
+export type Language = "fi" | "en" | "sv";
+```
+
+### The result
+
+The language is now shown in the app. However for the new language to work across the app, you will need to [add the translation to the modules](#4-adding-translations)
+![](https://rcbddkhvysexkvgqpcud.supabase.co/storage/v1/object/public/docs/translations/Screenshot%202025-09-25%20150617.png)
 
 ## 6. Checking Coverage
 
@@ -197,7 +268,7 @@ Run the translation checker script to ensure all UI strings are properly transla
 
 From the project root, run:
 
-Default check (relaxed mode):
+Default check:
 
 ```sh
 npm run check-translation
@@ -207,6 +278,17 @@ More aggressive detection (catches more, but may include false positives):
 
 ```sh
 npm run check-translation:strict
+```
+
+### All available translation checks
+
+```json
+"check-translation": "cd frontend && npx tsx src/scripts/check-translations.ts",
+"check-translation:strict": "cd frontend && npx tsx src/scripts/check-translations.ts strict",
+"check-translation:relaxed": "cd frontend && npx tsx src/scripts/check-translations.ts",
+"check-translation:unused": "cd frontend && npx tsx src/scripts/clean-unused-translations.ts",
+"check-translation:clean": "cd frontend && npx tsx src/scripts/clean-unused-translations.ts --confirm",
+"check-translation:create": "cd frontend && npx tsx src/scripts/create-missing-translation-modules"
 ```
 
 **What is checked:**

--- a/frontend/src/components/ui/UserMenu.tsx
+++ b/frontend/src/components/ui/UserMenu.tsx
@@ -19,11 +19,7 @@ import {
   UserRound,
 } from "lucide-react";
 
-import {
-  Language,
-  SUPPORTED_LANGUAGES,
-  useLanguage,
-} from "@/context/LanguageContext";
+import { Language, useLanguage } from "@/context/LanguageContext";
 import { useAuth } from "@/hooks/useAuth";
 import { useProfile } from "@/hooks/useProfile";
 import { useRoles } from "@/hooks/useRoles";
@@ -31,6 +27,7 @@ import { useAppDispatch } from "@/store/hooks";
 import { setRedirectUrl } from "@/store/slices/uiSlice";
 import { getOrgLabel } from "@/utils/format";
 import { t } from "@/translations";
+import { SUPPORTED_LANGUAGES } from "@/translations/SUPPORTED_LANGUAGES";
 
 export const UserMenu: React.FC = () => {
   const {

--- a/frontend/src/context/LanguageContext.tsx
+++ b/frontend/src/context/LanguageContext.tsx
@@ -1,21 +1,9 @@
 // Added this to avoid refactoring 50+ files
 /* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useState, useContext } from "react";
-import { supportedLanguages } from "@/translations/modules/supportedLanguages";
+
 // Define available languages
 export type Language = "fi" | "en";
-export const SUPPORTED_LANGUAGES = [
-  {
-    lang: "English",
-    key: "en",
-    translations: supportedLanguages.en,
-  },
-  {
-    lang: "Finnish",
-    key: "fi",
-    translations: supportedLanguages.fi,
-  },
-];
 
 // Language context type
 type LanguageContextType = {

--- a/frontend/src/scripts/create-missing-translation-modules.ts
+++ b/frontend/src/scripts/create-missing-translation-modules.ts
@@ -8,7 +8,7 @@ import {
   filterUIComponents,
   filterNonUIComponents,
 } from "../translations/utils/getAllComponents";
-import { SUPPORTED_LANGUAGES } from "../translations/SUPPORTED_LANGUAGES";
+import { SUPPORTED_LANGUAGES_KEYS } from "../translations/SUPPORTED_LANGUAGES";
 
 // Fix for ES module __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -29,7 +29,7 @@ function lowerFirst(str: string): string {
 // Get CLI params
 const args = process.argv.slice(2);
 const langArg = args.find((a) => /^[a-zA-Z,]+$/.test(a));
-const languages = langArg ? langArg.split(",") : SUPPORTED_LANGUAGES;
+const languages = langArg ? langArg.split(",") : SUPPORTED_LANGUAGES_KEYS;
 
 const rl = readline.createInterface({
   input: process.stdin,
@@ -102,4 +102,4 @@ async function main() {
   }
 }
 
-main();
+void main();

--- a/frontend/src/translations/SUPPORTED_LANGUAGES.ts
+++ b/frontend/src/translations/SUPPORTED_LANGUAGES.ts
@@ -1,1 +1,17 @@
-export const SUPPORTED_LANGUAGES = ["en", "fi"] as const;
+import { supportedLanguages } from "@/translations/modules/supportedLanguages";
+
+export const SUPPORTED_LANGUAGES = [
+  {
+    lang: "English",
+    key: "en",
+    translations: supportedLanguages.en,
+  },
+  {
+    lang: "Finnish",
+    key: "fi",
+    translations: supportedLanguages.fi,
+  },
+];
+
+// Array of just the language keys (country codes)
+export const SUPPORTED_LANGUAGES_KEYS = SUPPORTED_LANGUAGES.map((l) => l.key);

--- a/frontend/src/translations/utils/checkTranslationObjectStructure.ts
+++ b/frontend/src/translations/utils/checkTranslationObjectStructure.ts
@@ -1,4 +1,4 @@
-import { SUPPORTED_LANGUAGES } from "../SUPPORTED_LANGUAGES";
+import { SUPPORTED_LANGUAGES_KEYS } from "../SUPPORTED_LANGUAGES";
 
 export interface TranslationIssue {
   path: string;
@@ -10,9 +10,7 @@ function isTranslationLeaf(obj: unknown): boolean {
   if (typeof obj !== "object" || obj === null) return false;
   const keys = Object.keys(obj as Record<string, unknown>);
   // Explicitly cast `lang` to the union type
-  return keys.some((lang) =>
-    SUPPORTED_LANGUAGES.includes(lang as (typeof SUPPORTED_LANGUAGES)[number]),
-  );
+  return keys.some((lang) => SUPPORTED_LANGUAGES_KEYS.includes(lang));
 }
 
 export function checkTranslationObjectStructure(
@@ -34,7 +32,7 @@ export function checkTranslationObjectStructure(
 
   if (isTranslationLeaf(obj)) {
     // If keys do not match SUPPORTED_LANGUAGES, report which are missing
-    const missingLangs = SUPPORTED_LANGUAGES.filter(
+    const missingLangs = SUPPORTED_LANGUAGES_KEYS.filter(
       (lang) => !keys.includes(lang),
     );
     if (missingLangs.length > 0) {
@@ -45,10 +43,10 @@ export function checkTranslationObjectStructure(
     }
 
     // --- Required checks below ---
-    const translations = SUPPORTED_LANGUAGES.map((lang) => {
-      return (obj as Record<(typeof SUPPORTED_LANGUAGES)[number], unknown>)[
-        lang
-      ] as string;
+    const translations = SUPPORTED_LANGUAGES_KEYS.map((lang) => {
+      return (
+        obj as Record<(typeof SUPPORTED_LANGUAGES_KEYS)[number], unknown>
+      )[lang] as string;
     }).filter((t) => typeof t === "string" && t.length > 0);
 
     if (translations.length >= 2) {

--- a/frontend/src/translations/utils/checkUnusedTranslationKeys.ts
+++ b/frontend/src/translations/utils/checkUnusedTranslationKeys.ts
@@ -1,5 +1,5 @@
 import { getAllComponents } from "./getAllComponents";
-import { SUPPORTED_LANGUAGES } from "../SUPPORTED_LANGUAGES";
+import { SUPPORTED_LANGUAGES_KEYS } from "../SUPPORTED_LANGUAGES";
 import { t } from "../index.js";
 import fs from "fs";
 
@@ -19,8 +19,8 @@ function collectAllTranslationKeys(
 
   // Check if this is a translation leaf node
   const isTranslationObj =
-    SUPPORTED_LANGUAGES.every((lang) => objKeys.includes(lang)) &&
-    objKeys.length <= SUPPORTED_LANGUAGES.length;
+    SUPPORTED_LANGUAGES_KEYS.every((lang) => objKeys.includes(lang)) &&
+    objKeys.length <= SUPPORTED_LANGUAGES_KEYS.length;
 
   if (isTranslationObj && pathArr.length > 0) {
     keys.add(pathArr.join("."));

--- a/frontend/src/utils/imageUtils.ts
+++ b/frontend/src/utils/imageUtils.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { AllowedMimeType, FILE_CONSTRAINTS } from "@/types/storage";
 import { t } from "@/translations";
-import { SUPPORTED_LANGUAGES } from "@/translations/SUPPORTED_LANGUAGES";
+import { SUPPORTED_LANGUAGES_KEYS } from "@/translations/SUPPORTED_LANGUAGES";
 import { useLanguage } from "@/context/LanguageContext";
 import { toast } from "sonner";
 
@@ -12,7 +12,7 @@ export const getCroppedImg = async (
   _aspect: number,
   croppedAreaPixels: { width: number; height: number; x: number; y: number },
   rotation: number,
-  lang: (typeof SUPPORTED_LANGUAGES)[number] = "en",
+  lang: (typeof SUPPORTED_LANGUAGES_KEYS)[number] = "en",
 ): Promise<File> => {
   const image = await createImage(imageSrc);
   const canvas = document.createElement("canvas");
@@ -96,21 +96,26 @@ const createImage = (url: string): Promise<HTMLImageElement> =>
 export function validateImage(
   maxSize = FILE_CONSTRAINTS.MAX_FILE_SIZE,
   acceptedTypes = FILE_CONSTRAINTS.ALLOWED_FILE_TYPES,
-  lang: (typeof SUPPORTED_LANGUAGES)[number] = "en",
+  lang: (typeof SUPPORTED_LANGUAGES_KEYS)[number] = "en",
 ) {
   return z
     .instanceof(File)
     .refine((file) => file.size > 0, {
-      message: t.itemImageUpload.messages.emptyFile[lang],
+      message:
+        t.itemImageUpload.messages.emptyFile[
+          lang as keyof typeof t.itemImageUpload.messages.emptyFile
+        ],
     })
     .refine((file) => file.size <= maxSize, {
-      message: t.itemImageUpload.messages.fileTooLarge[lang].replace(
-        "{size}",
-        `${Math.round(maxSize / (1024 * 1024))}`,
-      ),
+      message: t.itemImageUpload.messages.fileTooLarge[
+        lang as keyof typeof t.itemImageUpload.messages.fileTooLarge
+      ].replace("{size}", `${Math.round(maxSize / (1024 * 1024))}`),
     })
     .refine((file) => acceptedTypes.includes(file.type as AllowedMimeType), {
-      message: t.itemImageUpload.messages.invalidFileType[lang],
+      message:
+        t.itemImageUpload.messages.invalidFileType[
+          lang as keyof typeof t.itemImageUpload.messages.invalidFileType
+        ],
     });
 }
 


### PR DESCRIPTION
The translations documentation were already quite up to date, I only added an example of what the structure of the modules generally should look like