### PR TITLE
add roles guard to @Patch :bookingId/cancel and @Delete :id/cancel

### DIFF
--- a/backend/src/modules/booking/booking.controller.ts
+++ b/backend/src/modules/booking/booking.controller.ts
@@ -346,14 +346,13 @@ export class BookingController {
 
   /**
    * Cancel a booking.
-   * Users can cancel their own bookings, while storage managers and tenant admins can cancel bookings within their organization.
+   * This endpoint is used to cancel own (users) or own org("requester", "storage_manager", "tenant_admin") bookings completely (not just booking-item).
    * @param id - ID of the booking to cancel
    * @param req - Authenticated request object
    * @returns Cancellation result
    */
-  //TODO: limit to activeContext
   @Delete(":id/cancel")
-  @Roles(["user", "storage_manager", "tenant_admin"], {
+  @Roles(["user", "requester", "storage_manager", "tenant_admin"], {
     match: "any",
     sameOrg: true,
   })
@@ -433,10 +432,14 @@ export class BookingController {
   }
 
   /**
-   * Mark items as cancelled from a booking.
-   * Meaning they will not be picked up
+   * Mark a list of booking-items as cancelled from booking (not the whole booking).
    */
+  //TODO: move into booking-items module
   @Patch(":bookingId/cancel")
+  @Roles(["user", "requester", "storage_manager", "tenant_admin"], {
+    match: "any",
+    sameOrg: true,
+  })
   async cancelItems(
     @Param("bookingId") bookingId: string,
     @Req() req: AuthRequest,

--- a/backend/src/modules/booking/booking.service.ts
+++ b/backend/src/modules/booking/booking.service.ts
@@ -1273,6 +1273,7 @@ export class BookingService {
     const isAdmin = this.roleService.hasAnyRole(req, [
       "tenant_admin",
       "storage_manager",
+      "requester",
     ]);
     const isOwner = booking.user_id === userId;
 


### PR DESCRIPTION
This pull request updates the booking cancellation logic to improve role handling and clarify endpoint behavior. The main focus is on expanding permissions to the "requester" role and making endpoint documentation and access control more precise.

**Role and Permission Updates:**

* Added the "requester" role to the list of roles allowed to cancel bookings and booking-items, both in the controller endpoints and in the service logic. [[1]](diffhunk://#diff-bae9dbb27af68c78ceb7e81bfd3f0f8632982686bbf5358b919d24fe7cc47814L349-R355) [[2]](diffhunk://#diff-bae9dbb27af68c78ceb7e81bfd3f0f8632982686bbf5358b919d24fe7cc47814L436-R442) [[3]](diffhunk://#diff-df275c7b4845761f5c4412d0541d9ef4bcf988008c702d1f0a93cce57d9a148eR1276)

**Endpoint Documentation and Structure:**

* Updated the documentation for the cancel booking endpoint to clarify that it cancels entire bookings for users and organizational roles, not just individual booking-items.
* Improved the documentation for the booking-items cancellation endpoint to specify that it cancels only a list of booking-items, not the whole booking, and added a TODO to consider moving this logic to the booking-items module.