### PR TITLE
make category_id required when adding items

### DIFF
--- a/backend/src/modules/storage-items/schema/item-schema.ts
+++ b/backend/src/modules/storage-items/schema/item-schema.ts
@@ -7,6 +7,7 @@ export const ItemSchema = z
     fi_item_name: z.string().min(1).max(100),
     fi_item_description: z.string().min(1).max(250),
     quantity: z.coerce.number().int().min(1),
+    category_id: z.uuid(),
   })
   .strip();
 

--- a/common/items/csv.types.ts
+++ b/common/items/csv.types.ts
@@ -4,6 +4,7 @@ export type CSVItem = {
   fi_item_name: string;
   fi_item_description: string;
   quantity: number;
+  category_id: string;
 };
 
 export type ProcessedCSV = {

--- a/common/items/form.types.ts
+++ b/common/items/form.types.ts
@@ -13,7 +13,7 @@ export type SelectedStorage = {
  */
 export type CreateItemType = {
   id: string;
-  category_id: string | null;
+  category_id: string;
   location: {
     id: string;
     name: string;

--- a/frontend/src/components/Admin/Items/AddItem/Steps/Summary.tsx
+++ b/frontend/src/components/Admin/Items/AddItem/Steps/Summary.tsx
@@ -136,12 +136,17 @@ function Summary() {
                                 );
                               } else if (errors.length === 1) {
                                 const [field, code] = errors[0].split(":");
+                                const translated =
+                                  t.itemSummary.fields?.[
+                                    field as keyof typeof t.itemSummary.fields
+                                  ]?.[lang] ||
+                                  t.itemSummary.fields.unknown[lang];
                                 return (
                                   <p>
                                     {code === "invalid_type"
                                       ? t.itemSummary.errorCodes.invalid_type[
                                           lang
-                                        ].replace("{field}", field)
+                                        ].replace("{field}", translated)
                                       : (
                                           t.itemSummary.errorCodes as Record<
                                             string,

--- a/frontend/src/components/ui/accordion.tsx
+++ b/frontend/src/components/ui/accordion.tsx
@@ -60,7 +60,7 @@ function AccordionContent({
   return (
     <AccordionPrimitive.Content
       data-slot="accordion-content"
-      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down text-sm"
       {...props}
     >
       <div className={cn("pt-0 pb-2", className)}>{children}</div>

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -8,7 +8,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex min-h-[80px] w-full rounded-md border bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       ref={ref}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,7 +35,7 @@
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: var(--iridiscent-blue)
+  --ring: var(--iridiscent-blue);
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);

--- a/frontend/src/store/utils/validate.ts
+++ b/frontend/src/store/utils/validate.ts
@@ -33,7 +33,7 @@ const imageSchema = z.object({
 
 export const createItemDto = z.object({
   id: z.string().uuid(),
-  category_id: z.nullable(z.string()),
+  category_id: z.string().uuid({ message: "category" }),
   location: z.object(
     {
       id: z.string().uuid({ message: "location" }),

--- a/frontend/src/translations/modules/addItemForm.ts
+++ b/frontend/src/translations/modules/addItemForm.ts
@@ -103,6 +103,26 @@ export const addItemForm = {
       fi: "Sinulla on keskeneräisiä tuotteita. Lataa tai poista ne vaihtaaksesi organisaatiota",
     },
   },
+  formDescription: {
+    category: {
+      prompt: {
+        en: "Can't find a matching category?",
+        fi: "Etkö löydä sopivaa kategoriaa?",
+      },
+      createOne: {
+        en: "Create one here",
+        fi: "Luo uusi tästä",
+      },
+      then: {
+        en: "then",
+        fi: "sitten",
+      },
+      refresh: {
+        en: "refresh",
+        fi: "päivitä",
+      },
+    },
+  },
   messages: {
     validation: {
       itemName: {
@@ -124,6 +144,10 @@ export const addItemForm = {
       quantity: {
         en: "Quantity is required",
         fi: "Määrä on pakollinen",
+      },
+      category_id: {
+        en: "Category is required",
+        fi: "Kategoria vaaditaan",
       },
     },
     error: {

--- a/frontend/src/translations/modules/itemSummary.ts
+++ b/frontend/src/translations/modules/itemSummary.ts
@@ -70,16 +70,6 @@ export const itemSummary = {
         fi: "Tuotenimen arvo (en) oli liian pitkä",
       },
     },
-    en_item_type: {
-      too_small: {
-        en: "The value for item type (en) was too short",
-        fi: "Tuotetyypin arvo (en) oli liian lyhyt",
-      },
-      too_big: {
-        en: "The value for item type (en) was too long",
-        fi: "Tuotetyypin arvo (en) oli liian pitkä",
-      },
-    },
     en_item_description: {
       too_small: {
         en: "The value for item description (en) was too short",
@@ -98,16 +88,6 @@ export const itemSummary = {
       too_big: {
         en: "The value for item name (fi) was too long",
         fi: "Tuotenimen arvo (fi) oli liian pitkä",
-      },
-    },
-    fi_item_type: {
-      too_small: {
-        en: "The value for item type (fi) was too short",
-        fi: "Tuotetyypin arvo (fi) oli liian lyhyt",
-      },
-      too_big: {
-        en: "The value for item type (fi) was too long",
-        fi: "Tuotetyypin arvo (fi) oli liian pitkä",
       },
     },
     fi_item_description: {
@@ -129,6 +109,28 @@ export const itemSummary = {
     invalid_type: {
       en: "An invalid type was provided for {field}",
       fi: "Virheellinen tyyppi annettu kentälle {field}",
+    },
+  },
+  fields: {
+    category_id: {
+      en: "category",
+      fi: "kategoria",
+    },
+    quantity: {
+      en: "quantity",
+      fi: "määrä",
+    },
+    item_description: {
+      en: "item description",
+      fi: "tuotteen kuvaus",
+    },
+    item_name: {
+      en: "item name",
+      fi: "tuotteen nimi",
+    },
+    unknown: {
+      en: "one field",
+      fi: "yksi kenttä",
     },
   },
 };


### PR DESCRIPTION
# 🔴  Make categories <ins>required</ins>
- Add category_id to item schema
- User cannot create new items using the form without a category
- User has to add a category_id to each item uploaded via CSV
- If user cannot find a good fit for their category, there is a prompt below which will open a new tab with the category creation, and a `refresh` button that reloads the categories so that they can choose their new category without losing their current item.

### Screenshots
<img width="1004" height="492" alt="Screenshot 2025-09-26 162609" src="https://github.com/user-attachments/assets/c5ff8875-9144-4eac-9c81-5fbdd0acaaa2" />
<img width="929" height="500" alt="Screenshot 2025-09-26 162620" src="https://github.com/user-attachments/assets/0e387784-a0fc-4761-8682-d90516ac7e93" />
<img width="938" height="607" alt="Screenshot 2025-09-26 162641" src="https://github.com/user-attachments/assets/3a953cf2-2ef2-4990-958a-153e8e162680" />
<img width="412" height="173" alt="Screenshot 2025-09-26 163024" src="https://github.com/user-attachments/assets/345772df-1598-43c1-a303-a8601797c921" />

## Future enhancements
- if possible, the CSV parser should have a way of finding categories using an english or finnish string. It would have to search the categories and attach the proper ID if a match is found.