### PR TITLE
Con2 415 remove addresses from organizations page

### DIFF
--- a/frontend/src/components/Items/UserPanel.tsx
+++ b/frontend/src/components/Items/UserPanel.tsx
@@ -36,9 +36,6 @@ const UserPanel = () => {
   const MAX_VISIBLE = 5;
   const [searchParams] = useSearchParams();
 
-  // State to track if URL params have been processed
-  const [urlParamsProcessed, setUrlParamsProcessed] = useState(false);
-
   useEffect(() => {
     void dispatch(fetchAllCategories({ page: 1, limit: 50 }));
     void dispatch(
@@ -204,25 +201,44 @@ const UserPanel = () => {
     }
   }, [isFilterVisible]);
 
-  // Process URL parameters when organizations are loaded
+  // Process URL parameters when organizations are loaded or search params change
   useEffect(() => {
-    if (organizations.length > 0 && !urlParamsProcessed) {
+    if (organizations.length > 0) {
       const organizationParam = searchParams.get("organization");
 
       if (organizationParam) {
         // Find organization by name and set it as selected
         const org = organizations.find((o) => o.name === organizationParam);
         if (org) {
-          setFilters((prev) => ({
-            ...prev,
-            orgIds: [org.id],
-          }));
+          setFilters((prev) => {
+            // Only update if the org filter is different
+            if (
+              !prev.orgIds ||
+              prev.orgIds.length !== 1 ||
+              prev.orgIds[0] !== org.id
+            ) {
+              return {
+                ...prev,
+                orgIds: [org.id],
+              };
+            }
+            return prev;
+          });
         }
+      } else {
+        // No organization parameter, clear org filter if it's set
+        setFilters((prev) => {
+          if (prev.orgIds && prev.orgIds.length > 0) {
+            return {
+              ...prev,
+              orgIds: [],
+            };
+          }
+          return prev;
+        });
       }
-
-      setUrlParamsProcessed(true);
     }
-  }, [organizations, searchParams, urlParamsProcessed]);
+  }, [organizations, searchParams]);
 
   return (
     <div className="flex min-h-screen w-full overflow-y-auto justify-around pt-4 md:pt-0 gap-4">

--- a/frontend/src/components/Items/UserPanel.tsx
+++ b/frontend/src/components/Items/UserPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { fetchFilteredTags, selectAllTags } from "@/store/slices/tagSlice";
-import { Outlet } from "react-router-dom";
+import { Outlet, useSearchParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { SlidersIcon } from "lucide-react";
@@ -34,6 +34,10 @@ const UserPanel = () => {
   const filterRef = useRef<HTMLDivElement>(null); // Ref for the filter panel position
   const organizations = useAppSelector(selectOrganizations);
   const MAX_VISIBLE = 5;
+  const [searchParams] = useSearchParams();
+
+  // State to track if URL params have been processed
+  const [urlParamsProcessed, setUrlParamsProcessed] = useState(false);
 
   useEffect(() => {
     void dispatch(fetchAllCategories({ page: 1, limit: 50 }));
@@ -199,6 +203,26 @@ const UserPanel = () => {
       filterRef.current.scrollTop = 0;
     }
   }, [isFilterVisible]);
+
+  // Process URL parameters when organizations are loaded
+  useEffect(() => {
+    if (organizations.length > 0 && !urlParamsProcessed) {
+      const organizationParam = searchParams.get("organization");
+
+      if (organizationParam) {
+        // Find organization by name and set it as selected
+        const org = organizations.find((o) => o.name === organizationParam);
+        if (org) {
+          setFilters((prev) => ({
+            ...prev,
+            orgIds: [org.id],
+          }));
+        }
+      }
+
+      setUrlParamsProcessed(true);
+    }
+  }, [organizations, searchParams, urlParamsProcessed]);
 
   return (
     <div className="flex min-h-screen w-full overflow-y-auto justify-around pt-4 md:pt-0 gap-4">

--- a/frontend/src/components/Organization/OrganizationInfo.tsx
+++ b/frontend/src/components/Organization/OrganizationInfo.tsx
@@ -1,6 +1,12 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import { OrganizationDetails } from "@/types/organization";
-import { Building2 } from "lucide-react";
+import { Building2, ArrowRight, Users } from "lucide-react";
+import { useLanguage } from "@/context/LanguageContext";
+import { t } from "@/translations";
+import { Button } from "@/components/ui/button";
+import { useRoles } from "@/hooks/useRoles";
+import { formatRoleName } from "@/utils/format";
 
 interface OrganizationInfoProps {
   organization: OrganizationDetails;
@@ -9,32 +15,80 @@ interface OrganizationInfoProps {
 const OrganizationInfo: React.FC<OrganizationInfoProps> = ({
   organization,
 }) => {
+  const { lang } = useLanguage();
+  const { currentUserOrganizations } = useRoles();
+
+  // Get user's role information for this organization
+  const userOrgRole = currentUserOrganizations.find(
+    (org) => org.organization_id === organization.id,
+  );
+
   return (
     <div className="organization-info space-y-6 p-6">
       {/* Organization Header */}
-      <div className="flex items-center gap-4">
-        <div className="h-24 w-24 rounded-full bg-gray-200 flex items-center justify-center text-gray-500 overflow-hidden">
-          {organization.logo_picture_url ? (
-            <img
-              src={organization.logo_picture_url}
-              alt={`${organization.name} logo`}
-              className="h-full w-full object-cover"
-            />
-          ) : (
-            <Building2 className="h-10 w-10" />
+      <section className="w-full max-w-xl px-4 sm:px-6 md:px-8 mx-auto mb-6">
+        <div className="flex flex-col items-center text-center gap-6">
+          <div className="w-full flex justify-start">
+            <Button asChild variant="secondary">
+              <Link to="/organizations" className="gap-2">
+                <ArrowRight className="h-4 w-4 rotate-180" />
+                <span>{t.organizationList.actions.backButton[lang]}</span>
+              </Link>
+            </Button>
+          </div>
+          <div className="h-24 w-24 rounded-xl bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center overflow-hidden shadow-sm">
+            {organization.logo_picture_url ? (
+              <img
+                src={organization.logo_picture_url}
+                alt={`${organization.name} logo`}
+                className="h-24 w-24 object-cover rounded-xl"
+              />
+            ) : (
+              <Building2 className="h-12 w-12 text-blue-600" />
+            )}
+          </div>
+
+          <h2 className="text-2xl font-bold text-center mb-2">
+            {organization.name}
+          </h2>
+
+          {/* Member Information */}
+          {userOrgRole && (
+            <div className="flex items-center justify-center gap-2 px-4 py-2 bg-green-50 border border-green-200 rounded-lg mb-2">
+              <Users className="h-4 w-4 text-green-600" />
+              <span className="text-sm font-medium text-green-700">
+                {t.organizationList.membership.youAreRole[lang].replace(
+                  "{role}",
+                  formatRoleName(userOrgRole.roles[0]),
+                )}
+                {userOrgRole.roles.length > 1 &&
+                  ` +${userOrgRole.roles.length - 1}`}
+              </span>
+            </div>
           )}
+
+          {organization.description && (
+            <p className="text-gray-700 text-center leading-relaxed">
+              {organization.description}
+            </p>
+          )}
+
+          {/* Browse Storage Button */}
+          <Button asChild variant="secondary">
+            <Link
+              to={`/storage?organization=${encodeURIComponent(organization.name)}`}
+              className="gap-2 group"
+            >
+              <span>
+                {t.organizationList.actions.browseStorage[lang]}{" "}
+                {organization.name}{" "}
+                {t.organizationList.actions.browseItems[lang]}
+              </span>
+              <ArrowRight className="h-4 w-4 group-hover:translate-x-0.5 transition-transform duration-200" />
+            </Link>
+          </Button>
         </div>
-
-        <h1 className="text-2xl font-bold">{organization.name}</h1>
-      </div>
-
-      {/* Description */}
-      <p className="text-gray-700">
-        {organization.description || "No description available."}
-      </p>
-
-      {/* Storage Link */}
-      <div></div>
+      </section>
     </div>
   );
 };

--- a/frontend/src/components/Organization/OrganizationsList.tsx
+++ b/frontend/src/components/Organization/OrganizationsList.tsx
@@ -130,7 +130,9 @@ const OrganizationsList = () => {
                   to={`/storage?organization=${encodeURIComponent(org.name)}`}
                   className="inline-flex items-center gap-2 text-blue-600 hover:text-blue-800 font-medium text-sm transition-colors duration-200 group"
                 >
-                  <span>{t.organizationList.actions.browseStorage[lang]}</span>
+                  <span>
+                    {t.organizationList.actions.browseStorage[lang]} {org.name}
+                  </span>
                   <ArrowRight className="h-4 w-4 group-hover:translate-x-1 transition-transform duration-200" />
                 </Link>
               </div>

--- a/frontend/src/components/Organization/OrganizationsList.tsx
+++ b/frontend/src/components/Organization/OrganizationsList.tsx
@@ -34,19 +34,24 @@ const OrganizationsList = () => {
 
   if (loading) {
     return (
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        {[...Array(3)].map((_item, i) => (
-          <Card key={i} className="animate-pulse">
-            <CardHeader>
-              <div className="h-4 bg-muted rounded w-3/4 mb-2"></div>
-              <div className="h-3 bg-muted rounded w-1/2"></div>
-            </CardHeader>
-            <CardContent>
-              <div className="h-3 bg-muted rounded w-full mb-2"></div>
-              <div className="h-3 bg-muted rounded w-2/3"></div>
-            </CardContent>
-          </Card>
-        ))}
+      <div className="container mx-auto px-4 py-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          {[...Array(6)].map((_item, i) => (
+            <Card key={i} className="animate-pulse">
+              <CardHeader className="pb-3">
+                <div className="flex items-center gap-3">
+                  <div className="h-10 w-10 bg-muted rounded-lg"></div>
+                  <div className="h-4 bg-muted rounded w-1/2"></div>
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <div className="h-3 bg-muted rounded w-full mb-2"></div>
+                <div className="h-3 bg-muted rounded w-3/4 mb-3"></div>
+                <div className="h-3 bg-muted rounded w-1/3"></div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
       </div>
     );
   }
@@ -68,74 +73,75 @@ const OrganizationsList = () => {
     {} as Record<string, string[]>,
   );
 
+  // Filter out High Council and Global organizations
+  const filteredOrganizations = organizations.filter(
+    (org) =>
+      !org.name.toLowerCase().includes("high council") &&
+      !org.name.toLowerCase().includes("global"),
+  );
+
   return (
-    <div className="space-y-6 p-6">
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {organizations.map((org) => (
+    <div className="container mx-auto px-4 py-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+        {filteredOrganizations.map((org) => (
           <Card
             key={org.id}
-            className="relative flex flex-col h-full hover:shadow-lg transition-shadow duration-200 border-0 shadow-sm"
+            className="hover:shadow-md transition-shadow duration-200"
           >
-            <CardHeader className="pb-4">
-              <div className="flex items-start justify-between">
-                <div className="flex items-center gap-4 flex-1">
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3 flex-1">
                   {/* Organization logo */}
-                  <div className="h-12 w-12 rounded-xl bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center overflow-hidden shadow-sm">
+                  <div className="h-12 w-12 rounded-lg bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center overflow-hidden">
                     {org.logo_picture_url ? (
                       <img
                         src={org.logo_picture_url}
                         alt={t.organizationList.alt.organizationLogo[
                           lang
                         ].replace("{orgName}", org.name)}
-                        className="h-12 w-12 object-cover rounded-xl"
+                        className="h-10 w-10 object-cover rounded-lg"
                       />
                     ) : (
-                      <Building2 className="h-6 w-6 text-blue-600" />
+                      <Building2 className="h-5 w-5 text-blue-600" />
                     )}
                   </div>
                   <div className="flex-1 min-w-0">
-                    <CardTitle className="text-lg font-semibold text-gray-900 truncate">
+                    <CardTitle className="font-semibold text-gray-900 truncate">
                       {org.name}
                     </CardTitle>
                   </div>
                 </div>
 
-                {/* Membership indicator on the right */}
+                {/* Membership indicator */}
                 {userOrgRoles[org.id] && (
-                  <div className="flex flex-col items-end ml-4">
-                    <div className="flex items-center gap-2 text-sm text-green-600 font-medium">
-                      <Users className="h-4 w-4" />
-                      <span>
-                        {t.organizationList.membership.youAreRole[lang].replace(
-                          "{role}",
-                          formatRoleName(userOrgRoles[org.id][0]),
-                        )}
-                        {userOrgRoles[org.id].length > 1 &&
-                          ` +${userOrgRoles[org.id].length - 1}`}
-                      </span>
-                    </div>
+                  <div className="flex items-center gap-1 text-sm text-green-600 font-medium">
+                    <Users className="h-4 w-4" />
+                    <span>
+                      {formatRoleName(userOrgRoles[org.id][0])}
+                      {userOrgRoles[org.id].length > 1 &&
+                        ` +${userOrgRoles[org.id].length - 1}`}
+                    </span>
                   </div>
                 )}
               </div>
             </CardHeader>
 
-            <CardContent className="pt-0 flex-grow flex flex-col">
-              <CardDescription className="text-sm text-gray-600 mb-4 overflow-hidden">
-                {org.description ||
-                  t.organizationList.columns.description[lang]}
-              </CardDescription>
+            <CardContent className="pt-0">
+              {org.description && (
+                <CardDescription className="text-sm text-gray-600 mb-3 line-clamp-2">
+                  {org.description}
+                </CardDescription>
+              )}
 
-              <div className="mt-auto">
-                <Link
-                  to={`/storage?organization=${encodeURIComponent(org.name)}`}
-                  className="inline-flex items-center gap-2 text-blue-600 hover:text-blue-800 font-medium text-sm transition-colors duration-200 group"
-                >
-                  <span>
-                    {t.organizationList.actions.browseStorage[lang]} {org.name}
-                  </span>
-                  <ArrowRight className="h-4 w-4 group-hover:translate-x-1 transition-transform duration-200" />
-                </Link>
-              </div>
+              <Link
+                to={`/storage?organization=${encodeURIComponent(org.name)}`}
+                className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800 font-medium text-sm transition-colors duration-200 group"
+              >
+                <span>
+                  {t.organizationList.actions.browseStorage[lang]} {org.name}
+                </span>
+                <ArrowRight className="h-3 w-3 group-hover:translate-x-0.5 transition-transform duration-200" />
+              </Link>
             </CardContent>
           </Card>
         ))}

--- a/frontend/src/components/Organization/OrganizationsList.tsx
+++ b/frontend/src/components/Organization/OrganizationsList.tsx
@@ -7,7 +7,7 @@ import {
   selectOrganizationError,
 } from "@/store/slices/organizationSlice";
 import { Link } from "react-router-dom";
-import { Building2 } from "lucide-react";
+import { Building2, Users, ArrowRight } from "lucide-react";
 import { useRoles } from "@/hooks/useRoles";
 import {
   Card,
@@ -16,9 +16,9 @@ import {
   CardDescription,
   CardContent,
 } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { useLanguage } from "@/context/LanguageContext";
 import { t } from "@/translations";
+import { formatRoleName } from "@/utils/format";
 
 const OrganizationsList = () => {
   const dispatch = useAppDispatch();
@@ -70,55 +70,68 @@ const OrganizationsList = () => {
 
   return (
     <div className="space-y-6 p-6">
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {organizations.map((org) => (
-          <Card key={org.id} className="relative flex flex-col h-full">
-            <CardHeader>
-              <div className="flex items-center gap-4">
-                {/* Organization logo */}
-                <div className="h-10 w-10 rounded-full bg-gray-200 flex items-center justify-center overflow-hidden">
-                  {org.logo_picture_url ? (
-                    <img
-                      src={org.logo_picture_url}
-                      alt={`${org.name} logo`}
-                      className="h-10 w-10 object-cover"
-                    />
-                  ) : (
-                    <Building2 className="h-6 w-6 text-gray-500" />
-                  )}
+          <Card
+            key={org.id}
+            className="relative flex flex-col h-full hover:shadow-lg transition-shadow duration-200 border-0 shadow-sm"
+          >
+            <CardHeader className="pb-4">
+              <div className="flex items-start justify-between">
+                <div className="flex items-center gap-4 flex-1">
+                  {/* Organization logo */}
+                  <div className="h-12 w-12 rounded-xl bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center overflow-hidden shadow-sm">
+                    {org.logo_picture_url ? (
+                      <img
+                        src={org.logo_picture_url}
+                        alt={t.organizationList.alt.organizationLogo[
+                          lang
+                        ].replace("{orgName}", org.name)}
+                        className="h-12 w-12 object-cover rounded-xl"
+                      />
+                    ) : (
+                      <Building2 className="h-6 w-6 text-blue-600" />
+                    )}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <CardTitle className="text-lg font-semibold text-gray-900 truncate">
+                      {org.name}
+                    </CardTitle>
+                  </div>
                 </div>
-                <CardTitle className="text-lg font-xl">{org.name}</CardTitle>
+
+                {/* Membership indicator on the right */}
+                {userOrgRoles[org.id] && (
+                  <div className="flex flex-col items-end ml-4">
+                    <div className="flex items-center gap-2 text-sm text-green-600 font-medium">
+                      <Users className="h-4 w-4" />
+                      <span>
+                        {t.organizationList.membership.youAreRole[lang].replace(
+                          "{role}",
+                          formatRoleName(userOrgRoles[org.id][0]),
+                        )}
+                        {userOrgRoles[org.id].length > 1 &&
+                          ` +${userOrgRoles[org.id].length - 1}`}
+                      </span>
+                    </div>
+                  </div>
+                )}
               </div>
-              <CardDescription className="text-sm text-muted-foreground">
+            </CardHeader>
+
+            <CardContent className="pt-0 flex-grow flex flex-col">
+              <CardDescription className="text-sm text-gray-600 mb-4 overflow-hidden">
                 {org.description ||
                   t.organizationList.columns.description[lang]}
               </CardDescription>
-            </CardHeader>
-            <CardContent className="flex-grow flex flex-col">
-              {userOrgRoles[org.id] && (
-                <div className="mb-4">
-                  <h3 className="text-sm font-medium text-gray-700 mb-2">
-                    {t.organizationList.myRoles[lang]}
-                  </h3>
-                  <div className="flex flex-wrap gap-2">
-                    {userOrgRoles[org.id].map((role) => (
-                      <Badge
-                        key={role}
-                        variant="secondary"
-                        className="bg-green-100 text-green-600"
-                      >
-                        {role}
-                      </Badge>
-                    ))}
-                  </div>
-                </div>
-              )}
+
               <div className="mt-auto">
                 <Link
-                  to={`/organization/${org.slug}`}
-                  className="text-blue-500 hover:underline text-sm"
+                  to={`/storage?organization=${encodeURIComponent(org.name)}`}
+                  className="inline-flex items-center gap-2 text-blue-600 hover:text-blue-800 font-medium text-sm transition-colors duration-200 group"
                 >
-                  {t.organizationList.view[lang]}
+                  <span>{t.organizationList.actions.browseStorage[lang]}</span>
+                  <ArrowRight className="h-4 w-4 group-hover:translate-x-1 transition-transform duration-200" />
                 </Link>
               </div>
             </CardContent>

--- a/frontend/src/components/Organization/OrganizationsList.tsx
+++ b/frontend/src/components/Organization/OrganizationsList.tsx
@@ -81,14 +81,24 @@ const OrganizationsList = () => {
   );
 
   return (
-    <div className="container mx-auto px-4 py-6">
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8 m-10 gap-20 bg-white">
+      {/* Header Section */}
+      <section className="w-full max-w-2xl px-4 sm:px-6 md:px-8 mx-auto mb-6">
+        <h2 className="text-2xl font-bold text-center mb-2">
+          {t.organizationList.header.title[lang]}
+        </h2>
+        <p className="text-gray-700 text-center">
+          {t.organizationList.header.description[lang]}
+        </p>
+      </section>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5 sm:px-2 md:px-2 pb-10">
         {filteredOrganizations.map((org) => (
           <Card
             key={org.id}
-            className="hover:shadow-md transition-shadow duration-200"
+            className="hover:shadow-md transition-shadow duration-200 py-4 px-0"
           >
-            <CardHeader className="pb-3">
+            <CardHeader className="pb-1">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3 flex-1">
                   {/* Organization logo */}
@@ -125,23 +135,39 @@ const OrganizationsList = () => {
                 )}
               </div>
             </CardHeader>
-
-            <CardContent className="pt-0">
+            <CardContent className="pt-2">
               {org.description && (
-                <CardDescription className="text-sm text-gray-600 mb-3 line-clamp-2">
+                <CardDescription className="text-sm text-gray-600 mb-6 line-clamp-2">
                   {org.description}
                 </CardDescription>
               )}
 
-              <Link
-                to={`/storage?organization=${encodeURIComponent(org.name)}`}
-                className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800 font-medium text-sm transition-colors duration-200 group"
-              >
-                <span>
-                  {t.organizationList.actions.browseStorage[lang]} {org.name}
-                </span>
-                <ArrowRight className="h-3 w-3 group-hover:translate-x-0.5 transition-transform duration-200" />
-              </Link>
+              <div className="flex flex-row justify-between gap-2">
+                <Link
+                  to={`/storage?organization=${encodeURIComponent(org.name)}`}
+                  className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800 font-medium text-sm transition-colors duration-200 group"
+                >
+                  <span>
+                    {t.organizationList.actions.browseStorage[lang]} {org.name}{" "}
+                    {t.organizationList.actions.browseItems[lang]}
+                  </span>
+                  <ArrowRight className="h-3 w-3 group-hover:translate-x-0.5 transition-transform duration-200" />
+                </Link>
+
+                {org.slug ? (
+                  <Link
+                    to={`/organization/${org.slug}`}
+                    className="inline-flex items-center gap-1 text-gray-600 hover:text-gray-800 font-medium text-sm transition-colors duration-200 group"
+                  >
+                    <span>{t.organizationList.actions.readMore[lang]}</span>
+                    <ArrowRight className="h-3 w-3 group-hover:translate-x-0.5 transition-transform duration-200" />
+                  </Link>
+                ) : (
+                  <span className="text-gray-400 text-sm">
+                    {t.organizationList.actions.readMore[lang]} (unavailable)
+                  </span>
+                )}
+              </div>
             </CardContent>
           </Card>
         ))}

--- a/frontend/src/pages/OrganizationPage.tsx
+++ b/frontend/src/pages/OrganizationPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import {
@@ -7,15 +7,7 @@ import {
   selectOrganizationError,
   selectedOrganization,
 } from "@/store/slices/organizationSlice";
-import {
-  fetchAllOrgLocations,
-  selectOrgLocations,
-  selectOrgLocationsLoading,
-  clearOrgLocations,
-  selectOrgLocationsError,
-} from "@/store/slices/organizationLocationsSlice";
 import OrganizationInfo from "../components/Organization/OrganizationInfo";
-import LocationsList from "@/components/Admin/OrgManagement/LocationsList";
 import { useLanguage } from "@/context/LanguageContext";
 import { t } from "@/translations";
 
@@ -23,135 +15,54 @@ const OrganizationPage = () => {
   const { lang } = useLanguage();
   const { org_slug } = useParams();
   const dispatch = useAppDispatch();
-  const [fetchError, setFetchError] = useState<string | null>(null);
-
-  // Track the active request to prevent race conditions
-  const activeRequestSlugRef = useRef<string | undefined>(org_slug);
 
   // Get data from Redux store
   const organization = useAppSelector(selectedOrganization);
-  const orgLocations = useAppSelector(selectOrgLocations);
   const organizationLoading = useAppSelector(selectOrganizationLoading);
-  const locationsLoading = useAppSelector(selectOrgLocationsLoading);
   const organizationError = useAppSelector(selectOrganizationError);
-  const locationsError = useAppSelector(selectOrgLocationsError);
 
-  // Update the reference of the current active slug when it changes
+  // Fetch organization data when slug changes
   useEffect(() => {
-    activeRequestSlugRef.current = org_slug;
-  }, [org_slug]);
-
-  // Reset state and fetch data when slug changes
-  useEffect(() => {
-    setFetchError(null);
-
-    // Clear any existing data in the store
-    dispatch(clearOrgLocations());
-
-    // Fetch new organization data
     if (org_slug) {
-      const fetchData = async () => {
-        try {
-          // First fetch organization data
-          const orgAction = await dispatch(fetchOrganizationBySlug(org_slug));
-
-          // Check if we successfully got the organization
-          if (fetchOrganizationBySlug.fulfilled.match(orgAction)) {
-            // Make sure we're still on the same page
-            if (activeRequestSlugRef.current !== org_slug) {
-              return; // We've navigated away, abort
-            }
-
-            const org = orgAction.payload;
-            if (org?.id) {
-              // Fetch locations using the organization ID
-              await dispatch(
-                fetchAllOrgLocations({
-                  orgId: org.id,
-                  pageSize: 100,
-                  currentPage: 1,
-                }),
-              ).unwrap();
-
-              // Verify we're still on the same page after locations fetch
-              if (activeRequestSlugRef.current !== org_slug) {
-                dispatch(clearOrgLocations()); // Clean up if navigated away
-              }
-            }
-          }
-        } catch (err) {
-          console.error("Error in data fetching:", err);
-          // Only set error if we're still on the same page
-          if (activeRequestSlugRef.current === org_slug) {
-            setFetchError("Failed to load data. Please try again.");
-          }
-        }
-      };
-
-      void fetchData();
+      void dispatch(fetchOrganizationBySlug(org_slug));
     }
-
-    // Clean up when unmounting or slug changes
-    return () => {
-      dispatch(clearOrgLocations());
-    };
   }, [org_slug, dispatch]);
 
-  // Combine the errors from organization and locations
-  const error = organizationError || locationsError || fetchError;
-
   // Handle error state
-  if (error) {
+  if (organizationError) {
     return (
-      <div className="text-center py-10 text-red-500">
-        {t.organizationPage.error[lang]} {error}
+      <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 md:px-8 m-10 gap-20 box-shadow-lg rounded-lg bg-white">
+        <div className="text-center py-10 text-red-500">
+          {t.organizationPage.error[lang]} {organizationError}
+        </div>
       </div>
     );
   }
 
   // Handle loading state
-  if (organizationLoading || (organization && locationsLoading)) {
+  if (organizationLoading) {
     return (
-      <div className="text-center py-10">
-        {t.organizationPage.loadingOrganization[lang]}
+      <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 md:px-8 m-10 gap-20 box-shadow-lg rounded-lg bg-white">
+        <div className="text-center py-10">
+          {t.organizationPage.loadingOrganization[lang]}
+        </div>
       </div>
     );
   }
 
   if (!organization) {
     return (
-      <div className="text-center py-10">
-        {t.organizationPage.organizationNotFound[lang]}
+      <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 md:px-8 m-10 gap-20 box-shadow-lg rounded-lg bg-white">
+        <div className="text-center py-10">
+          {t.organizationPage.organizationNotFound[lang]}
+        </div>
       </div>
     );
   }
 
-  // Filter locations to ensure they belong to the current organization
-  const displayLocations = orgLocations.filter(
-    (location) => location.organization_id === organization.id,
-  );
-
   return (
-    <div className="organization-page space-y-6">
-      {/* Organization Info */}
+    <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 md:px-8 m-10 gap-20 box-shadow-lg rounded-lg bg-white">
       <OrganizationInfo organization={organization} />
-
-      {/* Locations List */}
-      <div>
-        <h2 className="text-xl font-semibold mb-4">
-          {t.organizationPage.locations[lang]}
-        </h2>
-
-        {/* Error message */}
-        {fetchError && <div className="text-red-500 mb-4">{fetchError}</div>}
-
-        <LocationsList
-          locations={displayLocations}
-          loading={locationsLoading}
-          showActions={false}
-          organizationId={organization.id}
-        />
-      </div>
     </div>
   );
 };

--- a/frontend/src/translations/modules/organizationsList.ts
+++ b/frontend/src/translations/modules/organizationsList.ts
@@ -19,6 +19,24 @@ export const organizationList = {
     fi: "Omat roolit",
     en: "My roles",
   },
+  membership: {
+    youAreRole: {
+      fi: "Olet {role} täällä",
+      en: "You are a {role} here",
+    },
+  },
+  actions: {
+    browseStorage: {
+      fi: "Selaa varastoa",
+      en: "Browse Storage",
+    },
+  },
+  alt: {
+    organizationLogo: {
+      fi: "{orgName} logo",
+      en: "{orgName} logo",
+    },
+  },
 };
 
 export const organizationDelete = {

--- a/frontend/src/translations/modules/organizationsList.ts
+++ b/frontend/src/translations/modules/organizationsList.ts
@@ -27,8 +27,8 @@ export const organizationList = {
   },
   actions: {
     browseStorage: {
-      fi: "Selaa varastoa",
-      en: "Browse Storage",
+      fi: "Selaa esineitä",
+      en: "Browse Items from",
     },
   },
   alt: {

--- a/frontend/src/translations/modules/organizationsList.ts
+++ b/frontend/src/translations/modules/organizationsList.ts
@@ -1,6 +1,16 @@
 import { common } from "./common";
 
 export const organizationList = {
+  header: {
+    title: {
+      fi: "Organisaatiot",
+      en: "Organizations",
+    },
+    description: {
+      fi: "Selaa eri organisaatioita ja niiden tarjoamia esineitä.",
+      en: "Browse different organizations and their available items.",
+    },
+  },
   columns: {
     description: {
       fi: "Kuvaus",
@@ -27,8 +37,20 @@ export const organizationList = {
   },
   actions: {
     browseStorage: {
-      fi: "Selaa esineitä",
-      en: "Browse Items from",
+      fi: "Selaa",
+      en: "Browse",
+    },
+    browseItems: {
+      fi: "esineitä",
+      en: "Items",
+    },
+    readMore: {
+      fi: "Lue lisää",
+      en: "Read More",
+    },
+    backButton: {
+      fi: "Takaisin",
+      en: "Back",
     },
   },
   alt: {


### PR DESCRIPTION
* Redesigned organization cards in `OrganizationsList.tsx` with improved layout, clearer membership indicators, and direct links to browse organization storage and read more about each organization. High Council and Global organizations are now filtered out from the list.

* Updated `OrganizationInfo.tsx` to provide a visually enhanced header, membership role display, a back button, and a prominent "Browse Storage" button.

* Added logic in `UserPanel.tsx` to automatically filter items by organization based on the URL parameter, keeping the filter state in sync with navigation. This help to create links to the storage page with certain filters already pre-selected (in this case for example Illusia items filtered).

* Removed locations/addresses from `OrganizationPage.tsx`.