### PR TITLE
reset 'too weak password' error on a new password input, update login title

### DIFF
--- a/frontend/src/components/Auth/PasswordReset.tsx
+++ b/frontend/src/components/Auth/PasswordReset.tsx
@@ -101,6 +101,27 @@ const PasswordReset = () => {
     return () => clearTimeout(timer);
   }, [navigate, recoveryToken]); //eslint-disable-line
 
+  useEffect(() => {
+    const handler = () => setError(null);
+
+    const observer = new MutationObserver(() => {
+      const passwordInput = document.querySelector('input[type="password"]');
+      if (passwordInput) {
+        passwordInput.addEventListener("input", handler);
+      }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => {
+      observer.disconnect();
+      const passwordInput = document.querySelector('input[type="password"]');
+      if (passwordInput) {
+        passwordInput.removeEventListener("input", handler);
+      }
+    };
+  }, []);
+
   return (
     <div className="flex min-h-screen relative items-center justify-center p-4 pb-0">
       <Card className="w-full max-w-md shadow-lg">

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -85,11 +85,11 @@ const LoginPage = () => {
                 className="text-center text-2xl font-bold text-primary mb-2"
                 data-cy="login-card-title"
               >
-                {
-                  t.login.titles[currentView as keyof typeof t.login.titles][
-                    lang
-                  ]
-                }
+                {state?.message
+                  ? t.login.resetSuccessTitle[lang]
+                  : t.login.titles[currentView as keyof typeof t.login.titles][
+                      lang
+                    ]}
               </CardTitle>
               <div
                 className="w-16 h-1 bg-gradient-to-r from-secondary to-highlight2 mx-auto rounded-full"

--- a/frontend/src/translations/modules/login.ts
+++ b/frontend/src/translations/modules/login.ts
@@ -21,6 +21,10 @@ export const login = {
     fi: "Salasana on päivitetty onnistuneesti. Ole hyvä ja kirjaudu sisään uudella salasanallasi.",
     en: "Password has been updated successfully. Please log in with your new password.",
   },
+  resetSuccessTitle: {
+    en: "Welcome back!",
+    fi: "Tervetuloa takaisin!",
+  },
   expiredLink: {
     fi: 'Salasanan nollauslinkki on vanhentunut. Pyydä uusi linkki käyttämällä "Unohditko salasanasi" -vaihtoehtoa alla.',
     en: 'Your password reset link has expired. Please request a new one using the "Forgot password" option below.',


### PR DESCRIPTION
This pull request improves the user experience of the password reset flow by updating the login page to display a friendlier title after a successful password reset and by ensuring error messages are cleared when the password input changes.

**Password reset flow improvements:**

* The login page (`LoginPage.tsx`) now displays a "Welcome back!" message (localized) after a successful password reset, instead of the standard login title.
* New translation keys (`resetSuccessTitle`) have been added for both English and Finnish in `login.ts` to support the updated title.

**Error handling enhancements:**

* In `PasswordReset.tsx`, a `MutationObserver` is used to automatically clear error messages when the password input field changes.