### PR TITLE
add scrollability to avarat and org logo uploaders

### DIFF
--- a/frontend/src/components/Admin/Organizations/OrganizationLogoUploader.tsx
+++ b/frontend/src/components/Admin/Organizations/OrganizationLogoUploader.tsx
@@ -185,7 +185,7 @@ const OrganizationLogoUploader: React.FC<OrganizationLogoUploaderProps> = ({
 
       {/* open the modal containing also the cropper*/}
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-[700px]">
+        <DialogContent className="max-w-[700px] max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="text-2xl font-semibold tracking-tight">
               {t.profilePicUploader.changeProfilePicture[lang]}

--- a/frontend/src/components/ProfilePictureUploader.tsx
+++ b/frontend/src/components/ProfilePictureUploader.tsx
@@ -173,7 +173,7 @@ const ProfilePictureUploader = () => {
 
       {/* open the modal containing also the cropper*/}
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-[700px]">
+        <DialogContent className="max-w-[700px] max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="text-2xl font-semibold tracking-tight">
               {t.profilePicUploader.changeProfilePicture[lang]}


### PR DESCRIPTION
Tiny fix:

* UI/UX enhancements for modal dialogs:
  * Updated the `DialogContent` components in both `OrganizationLogoUploader.tsx` and `ProfilePictureUploader.tsx` to set a maximum height of 90vh and enable vertical scrolling when content overflows. [[1]](diffhunk://#diff-582e476329918588bb8d32c899e6bd3433591de73a5f5b04c39839a6c881e11aL188-R188) [[2]](diffhunk://#diff-7b72dbad514cb78f10738a75ad7e740715d86c679ac8fecb3868ad0defe31b2bL176-R176)