### PR TITLE
Con2 426 fix unnecessary session expired please log in again error

### DIFF
--- a/frontend/src/hooks/useRoles.ts
+++ b/frontend/src/hooks/useRoles.ts
@@ -483,7 +483,7 @@ export const useRoles = () => {
   }, [refreshCurrentUserRoles, refreshAllUserRoles]);
 
   const setupPeriodicSessionCheck = useCallback(
-    (intervalMinutes = 5) => {
+    (intervalMinutes = 4) => {
       // Don't set up checks if not authenticated
       if (!isAuthenticated) return () => {};
 


### PR DESCRIPTION
This pull request improves authentication token management and error handling in the frontend API layer. The most significant changes include smarter JWT expiration checks, automatic session refresh on token expiry or 401 responses, and minor adjustments to session check intervals.

**Authentication and Token Management:**

* Updated the `getAuthToken` function in `frontend/src/api/axios.ts` to decode the JWT, check its expiration, and automatically refresh the session if the token is expired or about to expire (in 60 seconds). This helps prevent users from encountering expired token errors during normal usage.

**API Error Handling:**

* Enhanced the response interceptor in `frontend/src/api/axios.ts` to handle 401 Unauthorized errors by attempting to refresh the session and retrying the original request if the refresh succeeds. This makes authentication more robust and seamless for users.
* Improved the rejection logic in the response interceptor to ensure errors are properly propagated if they cannot be handled, increasing reliability and clarity in error reporting.

**Session Check Interval:**

* Changed the periodic session check interval in `frontend/src/hooks/useRoles.ts` from 5 minutes to 4 minutes, making session validation slightly more frequent to further reduce the risk of expired tokens impacting user experience.