### PR TITLE
Con2 437 global and high council orgs should not be deletable editable

### DIFF
--- a/backend/src/modules/organization/organizations.service.ts
+++ b/backend/src/modules/organization/organizations.service.ts
@@ -113,6 +113,24 @@ export class OrganizationsService {
   ): Promise<OrganizationRow> {
     const supabase = this.getClient(req);
 
+    // Check if organization exists and get its name
+    const { data: existingOrg, error: fetchError } = await supabase
+      .from("organizations")
+      .select("name")
+      .eq("id", id)
+      .single();
+
+    if (fetchError || !existingOrg) {
+      throw new NotFoundException("Organization not found");
+    }
+
+    // Prevent updating Global and High Council organizations
+    if (existingOrg.name === "Global" || existingOrg.name === "High Council") {
+      throw new BadRequestException(
+        "Cannot update Global or High Council organizations",
+      );
+    }
+
     const { data, error } = await supabase
       .from("organizations")
       .update({ ...org, updated_by: req.user.id })
@@ -276,7 +294,7 @@ export class OrganizationsService {
     // check if it exists and is not already deleted
     const { data: org, error: orgError } = await supabase
       .from("organizations")
-      .select("id, is_deleted")
+      .select("id, is_deleted, name")
       .eq("id", id)
       .single();
 
@@ -284,6 +302,13 @@ export class OrganizationsService {
 
     if (org.is_deleted) {
       throw new BadRequestException("Organization is already deleted");
+    }
+
+    // Prevent deletion of Global and High Council organizations
+    if (org.name === "Global" || org.name === "High Council") {
+      throw new BadRequestException(
+        "Cannot delete Global or High Council organizations",
+      );
     }
 
     // and soft-delete

--- a/backend/src/modules/organization/organizations.service.ts
+++ b/backend/src/modules/organization/organizations.service.ts
@@ -124,10 +124,10 @@ export class OrganizationsService {
       throw new NotFoundException("Organization not found");
     }
 
-    // Prevent updating Global and High Council organizations
-    if (existingOrg.name === "Global" || existingOrg.name === "High Council") {
+    // Prevent updating Global and High council organizations
+    if (existingOrg.name === "Global" || existingOrg.name === "High council") {
       throw new BadRequestException(
-        "Cannot update Global or High Council organizations",
+        "Cannot update Global or High council organizations",
       );
     }
 
@@ -304,10 +304,10 @@ export class OrganizationsService {
       throw new BadRequestException("Organization is already deleted");
     }
 
-    // Prevent deletion of Global and High Council organizations
-    if (org.name === "Global" || org.name === "High Council") {
+    // Prevent deletion of Global and High council organizations
+    if (org.name === "Global" || org.name === "High council") {
       throw new BadRequestException(
-        "Cannot delete Global or High Council organizations",
+        "Cannot delete Global or High council organizations",
       );
     }
 

--- a/frontend/src/components/Admin/Organizations/OrganizationDelete.tsx
+++ b/frontend/src/components/Admin/Organizations/OrganizationDelete.tsx
@@ -51,8 +51,9 @@ const OrganizationDelete = ({
       onClick={handleDelete}
       size="sm"
       title={t.organizationDelete.button.title[lang]}
-      className="text-red-600 hover:text-red-800 hover:bg-red-100"
+      className="text-red-600 hover:text-red-800 hover:bg-red-100 gap-2"
     >
+      {t.organizationDetailsPage.buttons.deleteOrg[lang]}
       <Trash2 className="h-4 w-4" />
     </Button>
   );

--- a/frontend/src/components/Admin/Organizations/OrganizationDelete.tsx
+++ b/frontend/src/components/Admin/Organizations/OrganizationDelete.tsx
@@ -51,10 +51,14 @@ const OrganizationDelete = ({
       onClick={handleDelete}
       size="sm"
       title={t.organizationDelete.button.title[lang]}
+      aria-label={t.organizationDelete.accessibility.deleteButton[lang].replace(
+        "{title}",
+        t.organizationDelete.button.title[lang],
+      )}
       className="text-red-300 hover:text-red-800 hover:bg-red-100 gap-2"
     >
       {t.organizationDetailsPage.buttons.deleteOrg[lang]}
-      <Trash2 className="h-4 w-4" />
+      <Trash2 className="h-4 w-4" aria-hidden="true" />
     </Button>
   );
 };

--- a/frontend/src/components/Admin/Organizations/OrganizationDelete.tsx
+++ b/frontend/src/components/Admin/Organizations/OrganizationDelete.tsx
@@ -51,7 +51,7 @@ const OrganizationDelete = ({
       onClick={handleDelete}
       size="sm"
       title={t.organizationDelete.button.title[lang]}
-      className="text-red-600 hover:text-red-800 hover:bg-red-100 gap-2"
+      className="text-red-300 hover:text-red-800 hover:bg-red-100 gap-2"
     >
       {t.organizationDetailsPage.buttons.deleteOrg[lang]}
       <Trash2 className="h-4 w-4" />

--- a/frontend/src/pages/AdminPanel/CreateOrganizationPage.tsx
+++ b/frontend/src/pages/AdminPanel/CreateOrganizationPage.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAppDispatch } from "@/store/hooks";
+import { createOrganization } from "@/store/slices/organizationSlice";
+import { ArrowLeft, Building2, Save } from "lucide-react";
+import { t } from "@/translations";
+import { useLanguage } from "@/context/LanguageContext";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+const CreateOrganizationPage = () => {
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const { lang } = useLanguage();
+
+  const [formData, setFormData] = useState({
+    name: "",
+    description: "",
+  });
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleBackToList = () => {
+    void navigate("/admin/organizations");
+  };
+
+  const handleSave = async () => {
+    if (!formData.name.trim()) {
+      toast.error(t.organizations.validation.nameRequired[lang]);
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await dispatch(createOrganization(formData)).unwrap();
+      toast.success(t.organizations.toasts.created[lang]);
+      void navigate("/admin/organizations");
+    } catch {
+      toast.error(t.organizations.toasts.creationFailed[lang]);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleInputChange = (field: keyof typeof formData, value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  return (
+    <div className="max-w-4xl mx-4 p-6 space-y-6">
+      <h1 className="text-xl">{t.organizationDetailsPage.createTitle[lang]}</h1>
+
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <Button onClick={handleBackToList} variant="secondary" size="sm">
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          {t.organizationDetailsPage.backButton[lang]}
+        </Button>
+
+        <div className="flex items-center space-x-2">
+          <Button
+            onClick={handleSave}
+            size="sm"
+            variant="outline"
+            disabled={isSubmitting || !formData.name.trim()}
+          >
+            <Save className="w-4 h-4 mr-2" />
+            {t.organizationDetailsPage.buttons.save[lang]}
+          </Button>
+        </div>
+      </div>
+
+      {/* Create Organization Card */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-xl flex items-center gap-2">
+              {t.organizationDetailsPage.createTitle[lang]}
+            </CardTitle>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-6">
+          {/* Placeholder Logo */}
+          <div className="flex justify-center">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="cursor-help">
+                    <Avatar className="w-20 h-20">
+                      <AvatarFallback>
+                        <Building2 className="h-10 w-10 text-gray-400" />
+                      </AvatarFallback>
+                    </Avatar>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>
+                    {t.organizationDetailsPage.tooltips.logoPlaceholder[lang]}
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+
+          {/* Organization Form */}
+          <div className="space-y-4 text-sm">
+            <div>
+              <strong>{t.organizationDetailsPage.fields.name[lang]}:</strong>
+              <Input
+                value={formData.name}
+                onChange={(e) => handleInputChange("name", e.target.value)}
+                className="mt-2"
+                placeholder={t.organizationDetailsPage.fields.name[lang]}
+                required
+              />
+            </div>
+
+            <div>
+              <strong>
+                {t.organizationDetailsPage.fields.description[lang]}:
+              </strong>
+              <Textarea
+                value={formData.description}
+                onChange={(e) =>
+                  handleInputChange("description", e.target.value)
+                }
+                className="mt-2"
+                rows={3}
+                placeholder={t.organizationDetailsPage.fields.description[lang]}
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default CreateOrganizationPage;

--- a/frontend/src/pages/AdminPanel/CreateOrganizationPage.tsx
+++ b/frontend/src/pages/AdminPanel/CreateOrganizationPage.tsx
@@ -119,21 +119,27 @@ const CreateOrganizationPage = () => {
           {/* Organization Form */}
           <div className="space-y-4 text-sm">
             <div>
-              <strong>{t.organizationDetailsPage.fields.name[lang]}:</strong>
+              <label htmlFor="org-name" className="font-semibold">
+                {t.organizationDetailsPage.fields.name[lang]}:
+              </label>
               <Input
+                id="org-name"
                 value={formData.name}
                 onChange={(e) => handleInputChange("name", e.target.value)}
                 className="mt-2"
                 placeholder={t.organizationDetailsPage.fields.name[lang]}
                 required
+                aria-required="true"
+                aria-describedby="org-name-error"
               />
             </div>
 
             <div>
-              <strong>
+              <label htmlFor="org-description" className="font-semibold">
                 {t.organizationDetailsPage.fields.description[lang]}:
-              </strong>
+              </label>
               <Textarea
+                id="org-description"
                 value={formData.description}
                 onChange={(e) =>
                   handleInputChange("description", e.target.value)
@@ -141,7 +147,14 @@ const CreateOrganizationPage = () => {
                 className="mt-2"
                 rows={3}
                 placeholder={t.organizationDetailsPage.fields.description[lang]}
+                aria-describedby="org-description-help"
               />
+              <div id="org-description-help" className="sr-only">
+                {
+                  t.organizationDetailsPage.accessibility.labels
+                    .descriptionHelp[lang]
+                }
+              </div>
             </div>
           </div>
         </CardContent>

--- a/frontend/src/pages/AdminPanel/OrganizationDetailsPage.tsx
+++ b/frontend/src/pages/AdminPanel/OrganizationDetailsPage.tsx
@@ -20,6 +20,7 @@ import { useLanguage } from "@/context/LanguageContext";
 import { Switch } from "@/components/ui/switch";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { toastConfirm } from "@/components/ui/toastConfirm";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
@@ -98,28 +99,47 @@ const OrganizationDetailsPage = () => {
     }
   };
 
-  const handleToggleActive = async (checked: boolean) => {
+  const handleToggleActive = (checked: boolean) => {
     if (!selectedOrg || isProtectedOrg) return;
 
-    try {
-      await dispatch(
-        updateOrganization({
-          id: selectedOrg.id,
-          data: { is_active: checked },
-        }),
-      ).unwrap();
-      toast.success(
-        checked
-          ? t.organizationDetailsPage.toasts.activateSuccess[lang]
-          : t.organizationDetailsPage.toasts.deactivateSuccess[lang],
-      );
-      // Update local state
-      setEditForm((prev) => ({ ...prev, is_active: checked }));
-      // Refresh the data
-      void dispatch(fetchOrganizationById(selectedOrg.id));
-    } catch {
-      toast.error(t.organizationDetailsPage.toasts.statusUpdateError[lang]);
-    }
+    toastConfirm({
+      title: checked
+        ? t.organizationDetailsPage.confirmation.statusChange.activateTitle[
+            lang
+          ]
+        : t.organizationDetailsPage.confirmation.statusChange.deactivateTitle[
+            lang
+          ],
+      description: checked
+        ? t.organizationDetailsPage.confirmation.statusChange
+            .activateDescription[lang]
+        : t.organizationDetailsPage.confirmation.statusChange
+            .deactivateDescription[lang],
+      confirmText:
+        t.organizationDetailsPage.confirmation.statusChange.confirm[lang],
+      cancelText:
+        t.organizationDetailsPage.confirmation.statusChange.cancel[lang],
+      onConfirm: async () => {
+        try {
+          await dispatch(
+            updateOrganization({
+              id: selectedOrg.id,
+              data: { is_active: checked },
+            }),
+          ).unwrap();
+          toast.success(
+            checked
+              ? t.organizationDetailsPage.toasts.activateSuccess[lang]
+              : t.organizationDetailsPage.toasts.deactivateSuccess[lang],
+          );
+          setEditForm((prev) => ({ ...prev, is_active: checked }));
+          void dispatch(fetchOrganizationById(selectedOrg.id));
+        } catch {
+          toast.error(t.organizationDetailsPage.toasts.statusUpdateError[lang]);
+        }
+      },
+      onCancel: () => {},
+    });
   };
 
   const handleBackToList = () => {
@@ -262,9 +282,14 @@ const OrganizationDetailsPage = () => {
               <span>{selectedOrg.slug || "—"}</span>
             </div>
 
-            <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2 justify-start">
               <strong>{t.organizationDetailsPage.fields.status[lang]}:</strong>
               <div className="flex items-center space-x-2">
+                <span>
+                  {(isEditing ? editForm.is_active : selectedOrg.is_active)
+                    ? t.organizationDetailsPage.fields.active[lang]
+                    : t.organizationDetailsPage.fields.inactive[lang]}
+                </span>
                 <Switch
                   checked={
                     isEditing ? editForm.is_active : selectedOrg.is_active
@@ -272,51 +297,50 @@ const OrganizationDetailsPage = () => {
                   onCheckedChange={handleToggleActive}
                   disabled={isProtectedOrg}
                 />
-                <span>
-                  {(isEditing ? editForm.is_active : selectedOrg.is_active)
-                    ? t.organizationDetailsPage.fields.active[lang]
-                    : t.organizationDetailsPage.fields.inactive[lang]}
-                </span>
               </div>
             </div>
 
-            <div>
-              <strong>
-                {t.organizationDetailsPage.fields.createdAt[lang]}:
-              </strong>{" "}
-              {selectedOrg.created_at
-                ? new Date(selectedOrg.created_at).toLocaleString()
-                : "—"}
-            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-10 text-xs text-muted-foreground">
+              <div>
+                <strong>
+                  {t.organizationDetailsPage.fields.createdAt[lang]}:
+                </strong>{" "}
+                {selectedOrg.created_at
+                  ? new Date(selectedOrg.created_at).toLocaleString()
+                  : "—"}
+              </div>
 
-            <div>
-              <strong>
-                {t.organizationDetailsPage.fields.createdBy[lang]}:
-              </strong>{" "}
-              {selectedOrg.created_by || "—"}
-            </div>
+              <div>
+                <strong>
+                  {t.organizationDetailsPage.fields.createdBy[lang]}:
+                </strong>{" "}
+                {selectedOrg.created_by || "—"}
+              </div>
 
-            <div>
-              <strong>
-                {t.organizationDetailsPage.fields.updatedAt[lang]}:
-              </strong>{" "}
-              {selectedOrg.updated_at
-                ? new Date(selectedOrg.updated_at).toLocaleString()
-                : "—"}
-            </div>
+              <div>
+                <strong>
+                  {t.organizationDetailsPage.fields.updatedAt[lang]}:
+                </strong>{" "}
+                {selectedOrg.updated_at
+                  ? new Date(selectedOrg.updated_at).toLocaleString()
+                  : "—"}
+              </div>
 
-            <div>
-              <strong>
-                {t.organizationDetailsPage.fields.updatedBy[lang]}:
-              </strong>{" "}
-              {selectedOrg.updated_by || "—"}
+              <div>
+                <strong>
+                  {t.organizationDetailsPage.fields.updatedBy[lang]}:
+                </strong>{" "}
+                {selectedOrg.updated_by || "—"}
+              </div>
             </div>
           </div>
         </CardContent>
       </Card>
-      <div className="flex justify-end">
-        <OrganizationDelete id={selectedOrg.id} onDeleted={handleDeleted} />
-      </div>
+      {!isProtectedOrg && (
+        <div className="flex justify-end">
+          <OrganizationDelete id={selectedOrg.id} onDeleted={handleDeleted} />
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/AdminPanel/OrganizationDetailsPage.tsx
+++ b/frontend/src/pages/AdminPanel/OrganizationDetailsPage.tsx
@@ -24,6 +24,7 @@ import { toastConfirm } from "@/components/ui/toastConfirm";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
 import OrganizationDelete from "@/components/Admin/Organizations/OrganizationDelete";
 import OrganizationLogoUploader from "@/components/Admin/Organizations/OrganizationLogoUploader";
 
@@ -253,6 +254,25 @@ const OrganizationDetailsPage = () => {
 
           {/* Organization Info */}
           <div className="space-y-4 text-sm">
+            <div>
+              <strong>{t.organizationDetailsPage.fields.name[lang]}:</strong>{" "}
+              {isEditing && !isProtectedOrg ? (
+                <Input
+                  value={editForm.name}
+                  onChange={(e) =>
+                    setEditForm((prev) => ({
+                      ...prev,
+                      name: e.target.value,
+                    }))
+                  }
+                  className="mt-2"
+                  placeholder={t.organizationDetailsPage.fields.name[lang]}
+                />
+              ) : (
+                <span>{selectedOrg.name}</span>
+              )}
+            </div>
+
             <div>
               <strong>
                 {t.organizationDetailsPage.fields.description[lang]}:

--- a/frontend/src/pages/AdminPanel/OrganizationDetailsPage.tsx
+++ b/frontend/src/pages/AdminPanel/OrganizationDetailsPage.tsx
@@ -255,9 +255,12 @@ const OrganizationDetailsPage = () => {
           {/* Organization Info */}
           <div className="space-y-4 text-sm">
             <div>
-              <strong>{t.organizationDetailsPage.fields.name[lang]}:</strong>{" "}
+              <label htmlFor="edit-org-name" className="font-semibold">
+                {t.organizationDetailsPage.fields.name[lang]}:
+              </label>{" "}
               {isEditing && !isProtectedOrg ? (
                 <Input
+                  id="edit-org-name"
                   value={editForm.name}
                   onChange={(e) =>
                     setEditForm((prev) => ({
@@ -267,6 +270,7 @@ const OrganizationDetailsPage = () => {
                   }
                   className="mt-2"
                   placeholder={t.organizationDetailsPage.fields.name[lang]}
+                  aria-required="true"
                 />
               ) : (
                 <span>{selectedOrg.name}</span>
@@ -274,11 +278,12 @@ const OrganizationDetailsPage = () => {
             </div>
 
             <div>
-              <strong>
+              <label htmlFor="edit-org-description" className="font-semibold">
                 {t.organizationDetailsPage.fields.description[lang]}:
-              </strong>{" "}
+              </label>{" "}
               {isEditing ? (
                 <Textarea
+                  id="edit-org-description"
                   value={editForm.description}
                   onChange={(e) =>
                     setEditForm((prev) => ({
@@ -288,12 +293,21 @@ const OrganizationDetailsPage = () => {
                   }
                   className="mt-2"
                   rows={3}
+                  aria-describedby="edit-description-help"
                 />
               ) : (
                 <span>
                   {selectedOrg.description ||
                     t.organizationDetailsPage.fields.noDescription[lang]}
                 </span>
+              )}
+              {isEditing && (
+                <div id="edit-description-help" className="sr-only">
+                  {
+                    t.organizationDetailsPage.accessibility.labels
+                      .descriptionHelp[lang]
+                  }
+                </div>
               )}
             </div>
 
@@ -316,6 +330,10 @@ const OrganizationDetailsPage = () => {
                   }
                   onCheckedChange={handleToggleActive}
                   disabled={isProtectedOrg}
+                  aria-label={`${(isEditing ? editForm.is_active : selectedOrg.is_active) ? t.organizationDetailsPage.accessibility.toggleStatus.deactivate[lang] : t.organizationDetailsPage.accessibility.toggleStatus.activate[lang]}${isProtectedOrg ? t.organizationDetailsPage.accessibility.toggleStatus.protected[lang] : ""}`.replace(
+                    "{orgName}",
+                    selectedOrg.name,
+                  )}
                 />
               </div>
             </div>

--- a/frontend/src/pages/AdminPanel/OrganizationDetailsPage.tsx
+++ b/frontend/src/pages/AdminPanel/OrganizationDetailsPage.tsx
@@ -22,7 +22,6 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import OrganizationDelete from "@/components/Admin/Organizations/OrganizationDelete";
 import OrganizationLogoUploader from "@/components/Admin/Organizations/OrganizationLogoUploader";
@@ -40,14 +39,13 @@ const OrganizationDetailsPage = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [editForm, setEditForm] = useState({
     name: "",
-    slug: "",
     description: "",
     is_active: true,
   });
 
   // Check if this is a protected organization
   const isProtectedOrg =
-    selectedOrg?.name === "Global" || selectedOrg?.name === "High Council";
+    selectedOrg?.name === "Global" || selectedOrg?.name === "High council";
 
   useEffect(() => {
     if (id) {
@@ -59,7 +57,6 @@ const OrganizationDetailsPage = () => {
     if (selectedOrg) {
       setEditForm({
         name: selectedOrg.name || "",
-        slug: selectedOrg.slug || "",
         description: selectedOrg.description || "",
         is_active: selectedOrg.is_active,
       });
@@ -78,7 +75,6 @@ const OrganizationDetailsPage = () => {
     if (selectedOrg) {
       setEditForm({
         name: selectedOrg.name || "",
-        slug: selectedOrg.slug || "",
         description: selectedOrg.description || "",
         is_active: selectedOrg.is_active,
       });
@@ -150,7 +146,7 @@ const OrganizationDetailsPage = () => {
         <p className="text-muted-foreground">
           {t.organizationDetailsPage.notFound[lang]}
         </p>
-        <Button onClick={handleBackToList} variant="outline">
+        <Button onClick={handleBackToList} variant="ghost">
           <ArrowLeft className="w-4 h-4 mr-2" />
           {t.organizationDetailsPage.backButton[lang]}
         </Button>
@@ -162,7 +158,7 @@ const OrganizationDetailsPage = () => {
     <div className="max-w-4xl mx-4 p-6 space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <Button onClick={handleBackToList} variant="ghost" size="sm">
+        <Button onClick={handleBackToList} variant="secondary" size="sm">
           <ArrowLeft className="w-4 h-4 mr-2" />
           {t.organizationDetailsPage.backButton[lang]}
         </Button>
@@ -174,13 +170,13 @@ const OrganizationDetailsPage = () => {
                 <>
                   <Button
                     onClick={handleCancelEdit}
-                    variant="outline"
+                    variant="default"
                     size="sm"
                   >
                     <X className="w-4 h-4 mr-2" />
                     {t.organizationDetailsPage.buttons.cancel[lang]}
                   </Button>
-                  <Button onClick={handleSave} size="sm">
+                  <Button onClick={handleSave} size="sm" variant="outline">
                     <Save className="w-4 h-4 mr-2" />
                     {t.organizationDetailsPage.buttons.save[lang]}
                   </Button>
@@ -212,7 +208,7 @@ const OrganizationDetailsPage = () => {
         </CardHeader>
 
         <CardContent className="space-y-6">
-          {/* Logo - Show uploader when editing and not protected, otherwise show static avatar */}
+          {/* Logo */}
           <div className="flex justify-center">
             {isEditing && !isProtectedOrg ? (
               <OrganizationLogoUploader
@@ -263,17 +259,7 @@ const OrganizationDetailsPage = () => {
 
             <div>
               <strong>{t.organizationDetailsPage.fields.slug[lang]}:</strong>{" "}
-              {isEditing ? (
-                <Input
-                  value={editForm.slug}
-                  onChange={(e) =>
-                    setEditForm((prev) => ({ ...prev, slug: e.target.value }))
-                  }
-                  className="mt-2"
-                />
-              ) : (
-                <span>{selectedOrg.slug || "—"}</span>
-              )}
+              <span>{selectedOrg.slug || "—"}</span>
             </div>
 
             <div className="flex items-center justify-between">

--- a/frontend/src/pages/AdminPanel/OrganizationDetailsPage.tsx
+++ b/frontend/src/pages/AdminPanel/OrganizationDetailsPage.tsx
@@ -1,0 +1,325 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useAppDispatch, useAppSelector } from "@/store/hooks";
+import {
+  fetchOrganizationById,
+  updateOrganization,
+  selectOrganizationLoading,
+  setSelectedOrganization,
+} from "@/store/slices/organizationSlice";
+import {
+  ArrowLeft,
+  Building2,
+  Edit,
+  LoaderCircle,
+  Save,
+  X,
+} from "lucide-react";
+import { t } from "@/translations";
+import { useLanguage } from "@/context/LanguageContext";
+import { Switch } from "@/components/ui/switch";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import OrganizationDelete from "@/components/Admin/Organizations/OrganizationDelete";
+import OrganizationLogoUploader from "@/components/Admin/Organizations/OrganizationLogoUploader";
+
+const OrganizationDetailsPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const { lang } = useLanguage();
+  const loading = useAppSelector(selectOrganizationLoading);
+  const selectedOrg = useAppSelector(
+    (state) => state.organizations.selectedOrganization,
+  );
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [editForm, setEditForm] = useState({
+    name: "",
+    slug: "",
+    description: "",
+    is_active: true,
+  });
+
+  // Check if this is a protected organization
+  const isProtectedOrg =
+    selectedOrg?.name === "Global" || selectedOrg?.name === "High Council";
+
+  useEffect(() => {
+    if (id) {
+      void dispatch(fetchOrganizationById(id));
+    }
+  }, [dispatch, id]);
+
+  useEffect(() => {
+    if (selectedOrg) {
+      setEditForm({
+        name: selectedOrg.name || "",
+        slug: selectedOrg.slug || "",
+        description: selectedOrg.description || "",
+        is_active: selectedOrg.is_active,
+      });
+    }
+  }, [selectedOrg]);
+
+  const handleEdit = () => {
+    if (isProtectedOrg) {
+      toast.error("Cannot edit Global or High Council organizations");
+      return;
+    }
+    setIsEditing(true);
+  };
+
+  const handleCancelEdit = () => {
+    if (selectedOrg) {
+      setEditForm({
+        name: selectedOrg.name || "",
+        slug: selectedOrg.slug || "",
+        description: selectedOrg.description || "",
+        is_active: selectedOrg.is_active,
+      });
+    }
+    setIsEditing(false);
+  };
+
+  const handleSave = async () => {
+    if (!selectedOrg || isProtectedOrg) return;
+
+    try {
+      await dispatch(
+        updateOrganization({ id: selectedOrg.id, data: editForm }),
+      ).unwrap();
+      toast.success(
+        t.organizations.toasts.updated[lang] || "Organization updated!",
+      );
+      setIsEditing(false);
+      // Refresh the data
+      void dispatch(fetchOrganizationById(selectedOrg.id));
+    } catch {
+      toast.error(
+        t.organizations.toasts.creationFailed[lang] || "Something went wrong.",
+      );
+    }
+  };
+
+  const handleToggleActive = async (checked: boolean) => {
+    if (!selectedOrg || isProtectedOrg) return;
+
+    try {
+      await dispatch(
+        updateOrganization({
+          id: selectedOrg.id,
+          data: { is_active: checked },
+        }),
+      ).unwrap();
+      toast.success(
+        checked
+          ? t.adminItemsTable.messages.toast.activateSuccess[lang]
+          : t.adminItemsTable.messages.toast.deactivateSuccess[lang],
+      );
+      // Update local state
+      setEditForm((prev) => ({ ...prev, is_active: checked }));
+      // Refresh the data
+      void dispatch(fetchOrganizationById(selectedOrg.id));
+    } catch {
+      toast.error(t.adminItemsTable.messages.toast.statusUpdateFail[lang]);
+    }
+  };
+
+  const handleBackToList = () => {
+    dispatch(setSelectedOrganization(null));
+    void navigate("/admin/organizations");
+  };
+
+  const handleDeleted = () => {
+    dispatch(setSelectedOrganization(null));
+    void navigate("/admin/organizations");
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-[400px]">
+        <LoaderCircle className="animate-spin text-muted" />
+      </div>
+    );
+  }
+
+  if (!selectedOrg) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[400px] space-y-4">
+        <p className="text-muted-foreground">Organization not found</p>
+        <Button onClick={handleBackToList} variant="outline">
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          Back to Organizations
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-4 p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <Button onClick={handleBackToList} variant="ghost" size="sm">
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          Back to Organizations
+        </Button>
+
+        <div className="flex items-center space-x-2">
+          {!isProtectedOrg && (
+            <>
+              {isEditing ? (
+                <>
+                  <Button
+                    onClick={handleCancelEdit}
+                    variant="outline"
+                    size="sm"
+                  >
+                    <X className="w-4 h-4 mr-2" />
+                    Cancel
+                  </Button>
+                  <Button onClick={handleSave} size="sm">
+                    <Save className="w-4 h-4 mr-2" />
+                    Save Changes
+                  </Button>
+                </>
+              ) : (
+                <Button onClick={handleEdit} variant="outline" size="sm">
+                  <Edit className="w-4 h-4 mr-2" />
+                  Edit
+                </Button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Organization Details Card */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-xl flex items-center gap-2">
+              {selectedOrg.name}
+              {isProtectedOrg && (
+                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
+                  Protected
+                </span>
+              )}
+            </CardTitle>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-6">
+          {/* Logo - Show uploader when editing and not protected, otherwise show static avatar */}
+          <div className="flex justify-center">
+            {isEditing && !isProtectedOrg ? (
+              <OrganizationLogoUploader
+                currentImage={selectedOrg.logo_picture_url}
+                organizationId={selectedOrg.id}
+                onLogoUpdated={(_url) => {
+                  void dispatch(fetchOrganizationById(selectedOrg.id));
+                }}
+              />
+            ) : (
+              <Avatar className="w-20 h-20">
+                <AvatarImage
+                  src={selectedOrg.logo_picture_url ?? undefined}
+                  alt={`${selectedOrg.name} logo`}
+                />
+                <AvatarFallback>
+                  <Building2 className="h-10 w-10 text-gray-400" />
+                </AvatarFallback>
+              </Avatar>
+            )}
+          </div>
+
+          {/* Organization Info */}
+          <div className="space-y-4 text-sm">
+            <div>
+              <strong>Description:</strong>{" "}
+              {isEditing ? (
+                <Textarea
+                  value={editForm.description}
+                  onChange={(e) =>
+                    setEditForm((prev) => ({
+                      ...prev,
+                      description: e.target.value,
+                    }))
+                  }
+                  className="mt-2"
+                  rows={3}
+                />
+              ) : (
+                <span>{selectedOrg.description || "—"}</span>
+              )}
+            </div>
+
+            <div>
+              <strong>Slug:</strong>{" "}
+              {isEditing ? (
+                <Input
+                  value={editForm.slug}
+                  onChange={(e) =>
+                    setEditForm((prev) => ({ ...prev, slug: e.target.value }))
+                  }
+                  className="mt-2"
+                />
+              ) : (
+                <span>{selectedOrg.slug || "—"}</span>
+              )}
+            </div>
+
+            <div className="flex items-center justify-between">
+              <strong>Active:</strong>
+              <div className="flex items-center space-x-2">
+                <Switch
+                  checked={
+                    isEditing ? editForm.is_active : selectedOrg.is_active
+                  }
+                  onCheckedChange={handleToggleActive}
+                  disabled={isProtectedOrg}
+                />
+                <span>
+                  {(isEditing ? editForm.is_active : selectedOrg.is_active)
+                    ? "Yes"
+                    : "No"}
+                </span>
+              </div>
+            </div>
+
+            <div>
+              <strong>Created At:</strong>{" "}
+              {selectedOrg.created_at
+                ? new Date(selectedOrg.created_at).toLocaleString()
+                : "—"}
+            </div>
+
+            <div>
+              <strong>Created By:</strong> {selectedOrg.created_by || "—"}
+            </div>
+
+            <div>
+              <strong>Updated At:</strong>{" "}
+              {selectedOrg.updated_at
+                ? new Date(selectedOrg.updated_at).toLocaleString()
+                : "—"}
+            </div>
+
+            <div>
+              <strong>Updated By:</strong> {selectedOrg.updated_by || "—"}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+      <div className="flex justify-end">
+        <OrganizationDelete id={selectedOrg.id} onDeleted={handleDeleted} />
+      </div>
+    </div>
+  );
+};
+
+export default OrganizationDetailsPage;

--- a/frontend/src/pages/AdminPanel/OrganizationDetailsPage.tsx
+++ b/frontend/src/pages/AdminPanel/OrganizationDetailsPage.tsx
@@ -68,7 +68,7 @@ const OrganizationDetailsPage = () => {
 
   const handleEdit = () => {
     if (isProtectedOrg) {
-      toast.error("Cannot edit Global or High Council organizations");
+      toast.error(t.organizationDetailsPage.toasts.protectedEditError[lang]);
       return;
     }
     setIsEditing(true);
@@ -93,16 +93,12 @@ const OrganizationDetailsPage = () => {
       await dispatch(
         updateOrganization({ id: selectedOrg.id, data: editForm }),
       ).unwrap();
-      toast.success(
-        t.organizations.toasts.updated[lang] || "Organization updated!",
-      );
+      toast.success(t.organizationDetailsPage.toasts.updateSuccess[lang]);
       setIsEditing(false);
       // Refresh the data
       void dispatch(fetchOrganizationById(selectedOrg.id));
     } catch {
-      toast.error(
-        t.organizations.toasts.creationFailed[lang] || "Something went wrong.",
-      );
+      toast.error(t.organizationDetailsPage.toasts.updateError[lang]);
     }
   };
 
@@ -118,15 +114,15 @@ const OrganizationDetailsPage = () => {
       ).unwrap();
       toast.success(
         checked
-          ? t.adminItemsTable.messages.toast.activateSuccess[lang]
-          : t.adminItemsTable.messages.toast.deactivateSuccess[lang],
+          ? t.organizationDetailsPage.toasts.activateSuccess[lang]
+          : t.organizationDetailsPage.toasts.deactivateSuccess[lang],
       );
       // Update local state
       setEditForm((prev) => ({ ...prev, is_active: checked }));
       // Refresh the data
       void dispatch(fetchOrganizationById(selectedOrg.id));
     } catch {
-      toast.error(t.adminItemsTable.messages.toast.statusUpdateFail[lang]);
+      toast.error(t.organizationDetailsPage.toasts.statusUpdateError[lang]);
     }
   };
 
@@ -151,10 +147,12 @@ const OrganizationDetailsPage = () => {
   if (!selectedOrg) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[400px] space-y-4">
-        <p className="text-muted-foreground">Organization not found</p>
+        <p className="text-muted-foreground">
+          {t.organizationDetailsPage.notFound[lang]}
+        </p>
         <Button onClick={handleBackToList} variant="outline">
           <ArrowLeft className="w-4 h-4 mr-2" />
-          Back to Organizations
+          {t.organizationDetailsPage.backButton[lang]}
         </Button>
       </div>
     );
@@ -166,7 +164,7 @@ const OrganizationDetailsPage = () => {
       <div className="flex items-center justify-between">
         <Button onClick={handleBackToList} variant="ghost" size="sm">
           <ArrowLeft className="w-4 h-4 mr-2" />
-          Back to Organizations
+          {t.organizationDetailsPage.backButton[lang]}
         </Button>
 
         <div className="flex items-center space-x-2">
@@ -180,17 +178,17 @@ const OrganizationDetailsPage = () => {
                     size="sm"
                   >
                     <X className="w-4 h-4 mr-2" />
-                    Cancel
+                    {t.organizationDetailsPage.buttons.cancel[lang]}
                   </Button>
                   <Button onClick={handleSave} size="sm">
                     <Save className="w-4 h-4 mr-2" />
-                    Save Changes
+                    {t.organizationDetailsPage.buttons.save[lang]}
                   </Button>
                 </>
               ) : (
                 <Button onClick={handleEdit} variant="outline" size="sm">
                   <Edit className="w-4 h-4 mr-2" />
-                  Edit
+                  {t.organizationDetailsPage.buttons.edit[lang]}
                 </Button>
               )}
             </>
@@ -206,7 +204,7 @@ const OrganizationDetailsPage = () => {
               {selectedOrg.name}
               {isProtectedOrg && (
                 <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
-                  Protected
+                  {t.organizationDetailsPage.protected[lang]}
                 </span>
               )}
             </CardTitle>
@@ -240,7 +238,9 @@ const OrganizationDetailsPage = () => {
           {/* Organization Info */}
           <div className="space-y-4 text-sm">
             <div>
-              <strong>Description:</strong>{" "}
+              <strong>
+                {t.organizationDetailsPage.fields.description[lang]}:
+              </strong>{" "}
               {isEditing ? (
                 <Textarea
                   value={editForm.description}
@@ -254,12 +254,15 @@ const OrganizationDetailsPage = () => {
                   rows={3}
                 />
               ) : (
-                <span>{selectedOrg.description || "—"}</span>
+                <span>
+                  {selectedOrg.description ||
+                    t.organizationDetailsPage.fields.noDescription[lang]}
+                </span>
               )}
             </div>
 
             <div>
-              <strong>Slug:</strong>{" "}
+              <strong>{t.organizationDetailsPage.fields.slug[lang]}:</strong>{" "}
               {isEditing ? (
                 <Input
                   value={editForm.slug}
@@ -274,7 +277,7 @@ const OrganizationDetailsPage = () => {
             </div>
 
             <div className="flex items-center justify-between">
-              <strong>Active:</strong>
+              <strong>{t.organizationDetailsPage.fields.status[lang]}:</strong>
               <div className="flex items-center space-x-2">
                 <Switch
                   checked={
@@ -285,32 +288,42 @@ const OrganizationDetailsPage = () => {
                 />
                 <span>
                   {(isEditing ? editForm.is_active : selectedOrg.is_active)
-                    ? "Yes"
-                    : "No"}
+                    ? t.organizationDetailsPage.fields.active[lang]
+                    : t.organizationDetailsPage.fields.inactive[lang]}
                 </span>
               </div>
             </div>
 
             <div>
-              <strong>Created At:</strong>{" "}
+              <strong>
+                {t.organizationDetailsPage.fields.createdAt[lang]}:
+              </strong>{" "}
               {selectedOrg.created_at
                 ? new Date(selectedOrg.created_at).toLocaleString()
                 : "—"}
             </div>
 
             <div>
-              <strong>Created By:</strong> {selectedOrg.created_by || "—"}
+              <strong>
+                {t.organizationDetailsPage.fields.createdBy[lang]}:
+              </strong>{" "}
+              {selectedOrg.created_by || "—"}
             </div>
 
             <div>
-              <strong>Updated At:</strong>{" "}
+              <strong>
+                {t.organizationDetailsPage.fields.updatedAt[lang]}:
+              </strong>{" "}
               {selectedOrg.updated_at
                 ? new Date(selectedOrg.updated_at).toLocaleString()
                 : "—"}
             </div>
 
             <div>
-              <strong>Updated By:</strong> {selectedOrg.updated_by || "—"}
+              <strong>
+                {t.organizationDetailsPage.fields.updatedBy[lang]}:
+              </strong>{" "}
+              {selectedOrg.updated_by || "—"}
             </div>
           </div>
         </CardContent>

--- a/frontend/src/pages/AdminPanel/Organizations.tsx
+++ b/frontend/src/pages/AdminPanel/Organizations.tsx
@@ -54,7 +54,7 @@ const Organizations = () => {
   const handleToggle = (id: string, checked: boolean) => {
     // Find the organization to check if it's protected
     const org = organizations.find((o) => o.id === id);
-    const isProtected = org?.name === "Global" || org?.name === "High Council";
+    const isProtected = org?.name === "Global" || org?.name === "High council";
 
     if (isProtected) return;
 
@@ -160,7 +160,7 @@ const Organizations = () => {
       cell: ({ row }) => {
         const isProtected =
           row.original.name === "Global" ||
-          row.original.name === "High Council";
+          row.original.name === "High council";
         return (
           <Switch
             checked={row.original.is_active}

--- a/frontend/src/pages/AdminPanel/Organizations.tsx
+++ b/frontend/src/pages/AdminPanel/Organizations.tsx
@@ -57,11 +57,11 @@ const Organizations = () => {
       ).unwrap();
       toast.success(
         checked
-          ? t.adminItemsTable.messages.toast.activateSuccess[lang]
-          : t.adminItemsTable.messages.toast.deactivateSuccess[lang],
+          ? t.organizations.toasts.activateSuccess[lang]
+          : t.organizations.toasts.deactivateSuccess[lang],
       );
     } catch {
-      toast.error(t.adminItemsTable.messages.toast.statusUpdateFail[lang]);
+      toast.error(t.organizations.toasts.statusUpdateError[lang]);
     }
   };
 
@@ -74,9 +74,7 @@ const Organizations = () => {
       // Reload list after creation
       void dispatch(fetchAllOrganizations({ page: currentPage, limit }));
     } catch {
-      toast.error(
-        t.organizations.toasts.creationFailed[lang] || "Something went wrong.",
-      );
+      toast.error(t.organizations.toasts.creationFailed[lang]);
     }
   };
 

--- a/frontend/src/pages/AdminPanel/Organizations.tsx
+++ b/frontend/src/pages/AdminPanel/Organizations.tsx
@@ -17,6 +17,7 @@ import { useLanguage } from "@/context/LanguageContext";
 import { Switch } from "@/components/ui/switch";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { toastConfirm } from "@/components/ui/toastConfirm";
 import OrganizationModal, {
   OrganizationFormValues,
 } from "@/components/Admin/Organizations/OrganizationModal";
@@ -50,19 +51,46 @@ const Organizations = () => {
   };
 
   // Handle toggle active/inactive
-  const handleToggle = async (id: string, checked: boolean) => {
-    try {
-      await dispatch(
-        updateOrganization({ id, data: { is_active: checked } }),
-      ).unwrap();
-      toast.success(
-        checked
-          ? t.organizations.toasts.activateSuccess[lang]
-          : t.organizations.toasts.deactivateSuccess[lang],
-      );
-    } catch {
-      toast.error(t.organizations.toasts.statusUpdateError[lang]);
-    }
+  const handleToggle = (id: string, checked: boolean) => {
+    // Find the organization to check if it's protected
+    const org = organizations.find((o) => o.id === id);
+    const isProtected = org?.name === "Global" || org?.name === "High Council";
+
+    if (isProtected) return;
+
+    toastConfirm({
+      title: checked
+        ? t.organizationDetailsPage.confirmation.statusChange.activateTitle[
+            lang
+          ]
+        : t.organizationDetailsPage.confirmation.statusChange.deactivateTitle[
+            lang
+          ],
+      description: checked
+        ? t.organizationDetailsPage.confirmation.statusChange
+            .activateDescription[lang]
+        : t.organizationDetailsPage.confirmation.statusChange
+            .deactivateDescription[lang],
+      confirmText:
+        t.organizationDetailsPage.confirmation.statusChange.confirm[lang],
+      cancelText:
+        t.organizationDetailsPage.confirmation.statusChange.cancel[lang],
+      onConfirm: async () => {
+        try {
+          await dispatch(
+            updateOrganization({ id, data: { is_active: checked } }),
+          ).unwrap();
+          toast.success(
+            checked
+              ? t.organizationDetailsPage.toasts.activateSuccess[lang]
+              : t.organizationDetailsPage.toasts.deactivateSuccess[lang],
+          );
+        } catch {
+          toast.error(t.organizationDetailsPage.toasts.statusUpdateError[lang]);
+        }
+      },
+      onCancel: () => {},
+    });
   };
 
   // Handle create organization form submit

--- a/frontend/src/pages/AdminPanel/Organizations.tsx
+++ b/frontend/src/pages/AdminPanel/Organizations.tsx
@@ -116,6 +116,10 @@ const Organizations = () => {
         <button
           className="text-primary hover:underline font-medium text-left"
           onClick={() => openDetailsPage(row.original)}
+          aria-label={t.organizations.accessibility.viewDetails[lang].replace(
+            "{orgName}",
+            row.original.name,
+          )}
         >
           {row.original.name}
         </button>
@@ -149,6 +153,10 @@ const Organizations = () => {
               handleToggle(row.original.id, checked)
             }
             disabled={isProtected}
+            aria-label={`${row.original.is_active ? t.organizations.accessibility.toggleStatus.deactivate[lang] : t.organizations.accessibility.toggleStatus.activate[lang]}${isProtected ? t.organizations.accessibility.toggleStatus.protected[lang] : ""}`.replace(
+              "{orgName}",
+              row.original.name,
+            )}
           />
         );
       },
@@ -183,8 +191,18 @@ const Organizations = () => {
       </div>
 
       {loading ? (
-        <div className="flex justify-center p-8">
-          <LoaderCircle className="animate-spin text-muted" />
+        <div
+          className="flex justify-center p-8"
+          role="status"
+          aria-live="polite"
+        >
+          <LoaderCircle
+            className="animate-spin text-muted"
+            aria-hidden="true"
+          />
+          <span className="sr-only">
+            {t.organizations.accessibility.loading[lang]}
+          </span>
         </div>
       ) : (
         <PaginatedDataTable

--- a/frontend/src/pages/AdminPanel/Organizations.tsx
+++ b/frontend/src/pages/AdminPanel/Organizations.tsx
@@ -6,7 +6,6 @@ import {
   selectOrganizations,
   selectOrganizationLoading,
   updateOrganization,
-  createOrganization,
 } from "@/store/slices/organizationSlice";
 import { OrganizationDetails } from "@/types/organization";
 import { Building2, LoaderCircle, Plus } from "lucide-react";
@@ -18,9 +17,6 @@ import { Switch } from "@/components/ui/switch";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { toastConfirm } from "@/components/ui/toastConfirm";
-import OrganizationModal, {
-  OrganizationFormValues,
-} from "@/components/Admin/Organizations/OrganizationModal";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { formatDate } from "date-fns";
 
@@ -33,7 +29,6 @@ const Organizations = () => {
   const totalPages = useAppSelector((state) => state.organizations.totalPages);
 
   const [currentPage, setCurrentPage] = useState(1);
-  const [modalOpen, setModalOpen] = useState(false);
   const limit = 10;
 
   // Fetch organizations on mount & page change
@@ -45,9 +40,8 @@ const Organizations = () => {
     void navigate(`/admin/organizations/${org.id}`);
   };
 
-  // Open modal in "create" mode only
-  const openCreateModal = () => {
-    setModalOpen(true);
+  const openCreatePage = () => {
+    void navigate("/admin/organizations/create");
   };
 
   // Handle toggle active/inactive
@@ -91,19 +85,6 @@ const Organizations = () => {
       },
       onCancel: () => {},
     });
-  };
-
-  // Handle create organization form submit
-  const onSubmit = async (data: OrganizationFormValues) => {
-    try {
-      await dispatch(createOrganization(data)).unwrap();
-      toast.success(t.organizations.toasts.created[lang]);
-      setModalOpen(false);
-      // Reload list after creation
-      void dispatch(fetchAllOrganizations({ page: currentPage, limit }));
-    } catch {
-      toast.error(t.organizations.toasts.creationFailed[lang]);
-    }
   };
 
   const handlePageChange = (newPage: number) => {
@@ -190,7 +171,7 @@ const Organizations = () => {
         {/* Add New Org button */}
         <div className="flex gap-4 justify-end">
           <Button
-            onClick={openCreateModal}
+            onClick={openCreatePage}
             variant="outline"
             size="sm"
             className="gap-2"
@@ -219,15 +200,6 @@ const Organizations = () => {
           })}
         />
       )}
-
-      {/* Create Modal */}
-      <OrganizationModal
-        open={modalOpen}
-        onOpenChange={setModalOpen}
-        onSubmit={onSubmit}
-        mode="create"
-        organization={null}
-      />
     </div>
   );
 };

--- a/frontend/src/pages/AdminPanel/Organizations.tsx
+++ b/frontend/src/pages/AdminPanel/Organizations.tsx
@@ -78,13 +78,11 @@ const Organizations = () => {
     }
   };
 
-  // Handle pagination
   const handlePageChange = (newPage: number) => {
     if (newPage < 1) return;
     setCurrentPage(newPage);
   };
 
-  // Table columns
   const columns: ColumnDef<OrganizationDetails>[] = [
     {
       header: t.organizations.columns.logo[lang],

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -18,6 +18,7 @@ import TagDetailsPage from "@/pages/AdminPanel/TagDetailsPage";
 import AddTag from "@/pages/AdminPanel/AddTag";
 import Logs from "@/pages/AdminPanel/Logs";
 import Organizations from "@/pages/AdminPanel/Organizations";
+import OrganizationDetailsPage from "@/pages/AdminPanel/OrganizationDetailsPage";
 import OrganizationLocations from "@/pages/AdminPanel/OrganizationLocations";
 import Categories from "@/pages/AdminPanel/Categories";
 
@@ -221,6 +222,14 @@ export const router = createBrowserRouter([
             element: (
               <ProtectedRoute allowedRoles={["super_admin"]}>
                 <Organizations />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: "organizations/:id",
+            element: (
+              <ProtectedRoute allowedRoles={["super_admin"]}>
+                <OrganizationDetailsPage />
               </ProtectedRoute>
             ),
           },

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -19,6 +19,7 @@ import AddTag from "@/pages/AdminPanel/AddTag";
 import Logs from "@/pages/AdminPanel/Logs";
 import Organizations from "@/pages/AdminPanel/Organizations";
 import OrganizationDetailsPage from "@/pages/AdminPanel/OrganizationDetailsPage";
+import CreateOrganizationPage from "@/pages/AdminPanel/CreateOrganizationPage";
 import OrganizationLocations from "@/pages/AdminPanel/OrganizationLocations";
 import Categories from "@/pages/AdminPanel/Categories";
 
@@ -222,6 +223,14 @@ export const router = createBrowserRouter([
             element: (
               <ProtectedRoute allowedRoles={["super_admin"]}>
                 <Organizations />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: "organizations/create",
+            element: (
+              <ProtectedRoute allowedRoles={["super_admin"]}>
+                <CreateOrganizationPage />
               </ProtectedRoute>
             ),
           },

--- a/frontend/src/translations/index.ts
+++ b/frontend/src/translations/index.ts
@@ -48,12 +48,12 @@ import { notification } from "./modules/notification";
 import { organizationLocations } from "./modules/organizationLocations";
 import { organizationLogoUploader } from "./modules/organizationLogoUploader";
 import { organizationPage } from "./modules/organizationPage";
-import { organizations } from "./modules/organizations";
-import { organizationDetailsPage } from "./modules/organizationDetailsPage";
 import {
-  organizationDelete,
-  organizationList,
-} from "./modules/organizationsList";
+  organizations,
+  organizationDelete as orgDelete,
+} from "./modules/organizations";
+import { organizationDetailsPage } from "./modules/organizationDetailsPage";
+import { organizationList } from "./modules/organizationsList";
 import { orgLocationManagement } from "./modules/orgLocationManagement";
 import { orgStep } from "./modules/orgStep";
 import { overdueBookings } from "./modules/OverdueBookings";
@@ -135,7 +135,7 @@ export const t = {
   notification,
   orgLocationManagement,
   orgStep,
-  organizationDelete,
+  organizationDelete: orgDelete,
   organizationDetailsPage,
   organizationList,
   organizationLocations,

--- a/frontend/src/translations/index.ts
+++ b/frontend/src/translations/index.ts
@@ -49,6 +49,7 @@ import { organizationLocations } from "./modules/organizationLocations";
 import { organizationLogoUploader } from "./modules/organizationLogoUploader";
 import { organizationPage } from "./modules/organizationPage";
 import { organizations } from "./modules/organizations";
+import { organizationDetailsPage } from "./modules/organizationDetailsPage";
 import {
   organizationDelete,
   organizationList,
@@ -135,6 +136,7 @@ export const t = {
   orgLocationManagement,
   orgStep,
   organizationDelete,
+  organizationDetailsPage,
   organizationList,
   organizationLocations,
   organizationLogoUploader,

--- a/frontend/src/translations/modules/organizationDetailsPage.ts
+++ b/frontend/src/translations/modules/organizationDetailsPage.ts
@@ -5,6 +5,10 @@ export const organizationDetailsPage = {
     fi: "Organisaation tiedot",
     en: "Organization Details",
   },
+  createTitle: {
+    fi: "Luo uusi organisaatio",
+    en: "Create New Organization",
+  },
   backButton: {
     fi: "Takaisin",
     en: "Back",
@@ -16,6 +20,12 @@ export const organizationDetailsPage = {
   protected: {
     fi: "Suojattu",
     en: "Protected",
+  },
+  tooltips: {
+    logoPlaceholder: {
+      fi: "Logo voidaan lisätä myöhemmin organisaation luonnin jälkeen",
+      en: "Logo can be added later after creating the organization",
+    },
   },
   buttons: {
     edit: {

--- a/frontend/src/translations/modules/organizationDetailsPage.ts
+++ b/frontend/src/translations/modules/organizationDetailsPage.ts
@@ -107,4 +107,32 @@ export const organizationDetailsPage = {
       en: "Failed to update status",
     },
   },
+  confirmation: {
+    statusChange: {
+      activateTitle: {
+        fi: "Aktivoi organisaatio",
+        en: "Activate Organization",
+      },
+      deactivateTitle: {
+        fi: "Deaktivoi organisaatio",
+        en: "Deactivate Organization",
+      },
+      activateDescription: {
+        fi: "Organisaation aktivointi tekee sen ja sen tuotteet näkyviksi koko sovelluksessa. Haluatko jatkaa?",
+        en: "Activating the organization will make it and its items visible app-wide. Do you want to continue?",
+      },
+      deactivateDescription: {
+        fi: "Organisaation deaktivointi piilottaa sen ja sen tuotteet koko sovelluksesta. Haluatko jatkaa?",
+        en: "Deactivating the organization will hide it and its items app-wide. Do you want to continue?",
+      },
+      confirm: {
+        fi: "Vahvista",
+        en: "Confirm",
+      },
+      cancel: {
+        fi: common.cancel.fi,
+        en: common.cancel.en,
+      },
+    },
+  },
 };

--- a/frontend/src/translations/modules/organizationDetailsPage.ts
+++ b/frontend/src/translations/modules/organizationDetailsPage.ts
@@ -145,4 +145,34 @@ export const organizationDetailsPage = {
       },
     },
   },
+  accessibility: {
+    labels: {
+      nameField: {
+        fi: "Organisaation nimi",
+        en: "Organization name",
+      },
+      descriptionField: {
+        fi: "Organisaation kuvaus",
+        en: "Organization description",
+      },
+      descriptionHelp: {
+        fi: "Valinnainen kuvaus organisaatiolle",
+        en: "Optional description for the organization",
+      },
+    },
+    toggleStatus: {
+      activate: {
+        fi: "Aktivoi {orgName} organisaatio",
+        en: "Activate {orgName} organization",
+      },
+      deactivate: {
+        fi: "Deaktivoi {orgName} organisaatio",
+        en: "Deactivate {orgName} organization",
+      },
+      protected: {
+        fi: " (suojattu organisaatio)",
+        en: " (protected organization)",
+      },
+    },
+  },
 };

--- a/frontend/src/translations/modules/organizationDetailsPage.ts
+++ b/frontend/src/translations/modules/organizationDetailsPage.ts
@@ -6,8 +6,8 @@ export const organizationDetailsPage = {
     en: "Organization Details",
   },
   backButton: {
-    fi: "Takaisin organisaatioihin",
-    en: "Back to Organizations",
+    fi: "Takaisin",
+    en: "Back",
   },
   notFound: {
     fi: "Organisaatiota ei löytynyt",

--- a/frontend/src/translations/modules/organizationDetailsPage.ts
+++ b/frontend/src/translations/modules/organizationDetailsPage.ts
@@ -1,0 +1,110 @@
+import { common } from "../modules/common";
+
+export const organizationDetailsPage = {
+  title: {
+    fi: "Organisaation tiedot",
+    en: "Organization Details",
+  },
+  backButton: {
+    fi: "Takaisin organisaatioihin",
+    en: "Back to Organizations",
+  },
+  notFound: {
+    fi: "Organisaatiota ei löytynyt",
+    en: "Organization not found",
+  },
+  protected: {
+    fi: "Suojattu",
+    en: "Protected",
+  },
+  buttons: {
+    edit: {
+      fi: "Muokkaa",
+      en: "Edit",
+    },
+    cancel: {
+      fi: common.cancel.fi,
+      en: common.cancel.en,
+    },
+    save: {
+      fi: "Tallenna muutokset",
+      en: "Save Changes",
+    },
+    deleteOrg: {
+      fi: "Poista organisaatio",
+      en: "Delete Organization",
+    },
+  },
+  fields: {
+    name: {
+      fi: common.personalData.name.fi,
+      en: common.personalData.name.en,
+    },
+    slug: {
+      fi: "Tunniste",
+      en: "Slug",
+    },
+    description: {
+      fi: "Kuvaus",
+      en: "Description",
+    },
+    noDescription: {
+      fi: "Ei kuvausta annettu",
+      en: "No description provided",
+    },
+    status: {
+      fi: "Tila",
+      en: "Status",
+    },
+    active: {
+      fi: "Aktiivinen",
+      en: "Active",
+    },
+    inactive: {
+      fi: "Ei-aktiivinen",
+      en: "Inactive",
+    },
+    createdAt: {
+      fi: "Luotu",
+      en: "Created At",
+    },
+    updatedAt: {
+      fi: "Päivitetty",
+      en: "Updated At",
+    },
+    createdBy: {
+      fi: "Luonut",
+      en: "Created By",
+    },
+    updatedBy: {
+      fi: "Päivittänyt",
+      en: "Updated By",
+    },
+  },
+  toasts: {
+    updateSuccess: {
+      fi: "Organisaatio päivitetty!",
+      en: "Organization updated!",
+    },
+    updateError: {
+      fi: "Jotain meni pieleen.",
+      en: "Something went wrong.",
+    },
+    protectedEditError: {
+      fi: "Ei voida muokata Global tai High Council organisaatioita",
+      en: "Cannot edit Global or High Council organizations",
+    },
+    activateSuccess: {
+      fi: "Organisaatio aktivoitu onnistuneesti",
+      en: "Organization activated successfully",
+    },
+    deactivateSuccess: {
+      fi: "Organisaatio deaktivoitu onnistuneesti",
+      en: "Organization deactivated successfully",
+    },
+    statusUpdateError: {
+      fi: "Tilan päivitys epäonnistui",
+      en: "Failed to update status",
+    },
+  },
+};

--- a/frontend/src/translations/modules/organizations.ts
+++ b/frontend/src/translations/modules/organizations.ts
@@ -130,14 +130,18 @@ export const organizations = {
       fi: "Organisaation luonti epäonnistui.",
       en: "Failed to create organization.",
     },
-  },
-  view: {
-    fi: "Näytä",
-    en: "View",
-  },
-  edit: {
-    fi: "Muokkaa",
-    en: "Edit",
+    activateSuccess: {
+      fi: "Organisaatio aktivoitu onnistuneesti",
+      en: "Organization activated successfully",
+    },
+    deactivateSuccess: {
+      fi: "Organisaatio deaktivoitu onnistuneesti",
+      en: "Organization deactivated successfully",
+    },
+    statusUpdateError: {
+      fi: "Tilan päivitys epäonnistui",
+      en: "Failed to update status",
+    },
   },
 };
 

--- a/frontend/src/translations/modules/organizations.ts
+++ b/frontend/src/translations/modules/organizations.ts
@@ -143,6 +143,30 @@ export const organizations = {
       en: "Failed to update status",
     },
   },
+  accessibility: {
+    viewDetails: {
+      fi: "Näytä {orgName} organisaation tiedot",
+      en: "View details for {orgName} organization",
+    },
+    toggleStatus: {
+      activate: {
+        fi: "Aktivoi {orgName} organisaatio",
+        en: "Activate {orgName} organization",
+      },
+      deactivate: {
+        fi: "Deaktivoi {orgName} organisaatio",
+        en: "Deactivate {orgName} organization",
+      },
+      protected: {
+        fi: " (suojattu organisaatio)",
+        en: " (protected organization)",
+      },
+    },
+    loading: {
+      fi: "Ladataan organisaatioita...",
+      en: "Loading organizations...",
+    },
+  },
 };
 
 export const organizationDelete = {
@@ -192,6 +216,12 @@ export const organizationDelete = {
     generalError: {
       en: "Something went wrong.",
       fi: "Jotain meni pieleen.",
+    },
+  },
+  accessibility: {
+    deleteButton: {
+      fi: "Poista organisaatio - {title}",
+      en: "Delete organization - {title}",
     },
   },
 };


### PR DESCRIPTION
This pull request introduces important backend and frontend changes to the organization management functionality, focusing on protecting special organizations ("Global" and "High council") from modification or deletion, and improving the admin UI for organization creation and editing.

### Backend: Organization Protection Logic

* Added checks in `OrganizationsService` to prevent updating or deleting organizations named "Global" or "High council", returning appropriate error responses if such actions are attempted. [[1]](diffhunk://#diff-38d70cb214e7049fb7192d2e1573a2debe949a1f807b09bbec354be0dfe47405R116-R133) [[2]](diffhunk://#diff-38d70cb214e7049fb7192d2e1573a2debe949a1f807b09bbec354be0dfe47405R307-R313)
* Modified organization queries to include the `name` field, enabling the above protection logic.

### Frontend: Admin Panel Improvements

* Added a new `CreateOrganizationPage` component, allowing admins to create organizations with form validation, success/error toasts, and navigation.
* Implemented a new `OrganizationDetailsPage` component, supporting viewing, editing, and toggling the status of organizations, with special handling to prevent editing or deleting protected organizations and displaying clear UI feedback.
* Improved the `OrganizationDelete` button for accessibility and UI clarity, including updated ARIA labels and button styling.