### PR TITLE
Con2 413 add self pickup date validation for the user

### DIFF
--- a/backend/src/modules/booking/booking.controller.ts
+++ b/backend/src/modules/booking/booking.controller.ts
@@ -439,6 +439,16 @@ export class BookingController {
     const supabase = req.supabase;
     const { item_ids: itemIds, location_id, org_id } = body;
 
+    if (
+      !location_id ||
+      typeof location_id !== "string" ||
+      location_id.trim() === ""
+    ) {
+      throw new BadRequestException(
+        "'location_id' (UUID string) is required in body",
+      );
+    }
+
     // Org ID is either provided in the body (self_pickup) or the headers (admin pickup)
     const orgId = org_id ?? (req.headers["x-org-id"] as string);
     return this.bookingService.confirmPickup(

--- a/frontend/src/api/services/bookings.ts
+++ b/frontend/src/api/services/bookings.ts
@@ -253,7 +253,7 @@ export const bookingsApi = {
    */
   pickUpItems: async (
     bookingId: string,
-    location_id?: string,
+    location_id: string,
     org_id?: string,
     itemIds?: string[],
   ): Promise<Booking> => {

--- a/frontend/src/components/Admin/Bookings/BookingPickupButton.tsx
+++ b/frontend/src/components/Admin/Bookings/BookingPickupButton.tsx
@@ -10,10 +10,11 @@ import { ReactNode } from "react";
 
 type BookingPickUpProps = {
   id: string;
-  location_id?: string;
+  location_id: string;
   org_id?: string;
   selectedItemIds?: string[];
   disabled?: boolean;
+  disabledReason?: string;
   onSuccess?: () => void;
   children?: ReactNode;
   className?: string;
@@ -26,6 +27,7 @@ const BookingPickupButton = ({
   selectedItemIds,
   onSuccess,
   disabled = false,
+  disabledReason,
   children,
   className,
 }: BookingPickUpProps) => {
@@ -62,13 +64,16 @@ const BookingPickupButton = ({
     });
   };
   const base_classes = "text-green-600 hover:text-green-800 hover:bg-green-100";
+  const defaultTitle = t.bookingList.buttons.pickedUp[lang];
+  const title = disabled && disabledReason ? disabledReason : defaultTitle;
 
   return (
     <Button
       variant="ghost"
       size="sm"
       disabled={disabled}
-      title={t.bookingList.buttons.pickedUp[lang]}
+      title={title}
+      aria-disabled={disabled}
       className={className ? [className, base_classes].join(" ") : base_classes}
       onClick={handlePickup}
     >

--- a/frontend/src/pages/MyBookingsPage.tsx
+++ b/frontend/src/pages/MyBookingsPage.tsx
@@ -346,6 +346,11 @@ const MyBookingsPage = () => {
 
         if (!location?.self_pickup) return null;
 
+        const isBeforeStart = new Date(item.start_date) > new Date();
+        const pickupDisabledReason = isBeforeStart
+          ? t.bookingPickup.errors.beforeStartDate[lang]
+          : undefined;
+
         return (
           <div className="flex gap-1">
             {/* Show pickup button if item status is confirmed */}
@@ -356,7 +361,8 @@ const MyBookingsPage = () => {
                 id={booking.id}
                 className="gap-1 h-8 text-xs"
                 org_id={item.provider_organization_id}
-                disabled={new Date(item.start_date) > new Date()}
+                disabled={isBeforeStart}
+                disabledReason={pickupDisabledReason}
               >
                 {t.myBookingsPage.buttons.pickedUp[lang]}
               </BookingPickupButton>

--- a/frontend/src/pages/MyBookingsPage.tsx
+++ b/frontend/src/pages/MyBookingsPage.tsx
@@ -356,6 +356,7 @@ const MyBookingsPage = () => {
                 id={booking.id}
                 className="gap-1 h-8 text-xs"
                 org_id={item.provider_organization_id}
+                disabled={new Date(item.start_date) > new Date()}
               >
                 {t.myBookingsPage.buttons.pickedUp[lang]}
               </BookingPickupButton>

--- a/frontend/src/store/slices/bookingsSlice.ts
+++ b/frontend/src/store/slices/bookingsSlice.ts
@@ -536,13 +536,13 @@ export const returnItems = createAsyncThunk<
 export const pickUpItems = createAsyncThunk<
   {
     bookingId: string;
-    location_id?: string;
+    location_id: string;
     org_id?: string;
     itemIds?: string[];
   },
   {
     bookingId: string;
-    location_id?: string;
+    location_id: string;
     org_id?: string;
     itemIds?: string[];
   },
@@ -1079,21 +1079,14 @@ export const bookingsSlice = createSlice({
       .addCase(pickUpItems.fulfilled, (state, action) => {
         state.loading = false;
         // Optimistically update currentBooking items to reflect pickup
-        const { bookingId, location_id, org_id, itemIds } = action.payload as {
-          bookingId: string;
-          location_id?: string;
-          org_id?: string;
-          itemIds?: string[];
-        };
+        const { bookingId, location_id, org_id, itemIds } = action.payload;
         if (
           state.currentBooking?.id === bookingId &&
           state.currentBooking.booking_items
         ) {
           state.currentBooking.booking_items =
             state.currentBooking.booking_items.map((bi) => {
-              const matchesLocation = location_id
-                ? bi.location_id === location_id
-                : true;
+              const matchesLocation = bi.location_id === location_id;
               const matchesOrg = org_id
                 ? bi.provider_organization_id === org_id
                 : true;

--- a/frontend/src/translations/modules/bookingPickup.ts
+++ b/frontend/src/translations/modules/bookingPickup.ts
@@ -38,5 +38,13 @@ export const bookingPickup = {
       fi: "Virheellinen varausnumero.",
       en: "Invalid booking ID.",
     },
+    multiLocation: {
+      fi: "Valitse tuotteet yhdestä sijainnista ennen noudon vahvistamista.",
+      en: "Select items from a single location before confirming pickup.",
+    },
+    beforeStartDate: {
+      fi: "Tuotteet voidaan merkitä noudetuiksi aikaisintaan aloituspäivänä.",
+      en: "Items can be marked as picked up on or after their start date.",
+    },
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "dependencies": {
         "@dotenvx/dotenvx": "^1.49.0",
-        "supabase": "^2.45.5"
+        "supabase": "^2.47.2"
       },
       "devDependencies": {
         "@postgrestools/postgrestools": "^0.15.0",
@@ -1098,16 +1098,16 @@
       }
     },
     "node_modules/supabase": {
-      "version": "2.45.5",
-      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.45.5.tgz",
-      "integrity": "sha512-/toOX6bHYx2TUNA5AtlzrKKfvctbLQ8R6QqvUCAT20KtZOkR14HpBYav3TNDaU5owPeB58cT5Uftvxw36Tb95A==",
+      "version": "2.47.2",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.47.2.tgz",
+      "integrity": "sha512-YvjjJXt21GsYvMBBJN3aKoGZf8QkCWU3hX5So/KsLRweY1YDu9mcEsrMdWp3ZYKQhoEMl9jDHG58SEQuFWGUfg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bin-links": "^5.0.0",
         "https-proxy-agent": "^7.0.2",
         "node-fetch": "^3.3.2",
-        "tar": "7.4.4"
+        "tar": "7.5.1"
       },
       "bin": {
         "supabase": "bin/supabase"
@@ -1133,9 +1133,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.4.tgz",
-      "integrity": "sha512-O1z7ajPkjTgEgmTGz0v9X4eqeEXTDREPTO77pVC1Nbs86feBU1Zhdg+edzavPmYW1olxkwsqA2v4uOw6E8LeDg==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
+      "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
       "license": "ISC",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
   },
   "dependencies": {
     "@dotenvx/dotenvx": "^1.49.0",
-    "supabase": "^2.45.5"
+    "supabase": "^2.47.2"
   }
 }

--- a/supabase/migrations/20251001105739_Prevent_Early_Pickup.sql
+++ b/supabase/migrations/20251001105739_Prevent_Early_Pickup.sql
@@ -1,7 +1,7 @@
 -- Prevent setting booking_items.status = 'picked_up' before the item start_date
 -- This policy is RESTRICTIVE and combines with existing permissive org-role policies.
--- It will block any update that attempts to set NEW.status to 'picked_up'
--- when NEW.start_date is still in the future (relative to now()).
+-- It will block any update that attempts to set status to 'picked_up'
+-- when start_date is still in the future (relative to now()).
 
 -- Safety: drop if it exists to allow re-run
 drop policy if exists "pickup_not_before_start" on public.booking_items;
@@ -12,9 +12,8 @@ create policy "pickup_not_before_start" on public.booking_items
   using (true)
   with check (
     -- Allow all updates except when setting status to picked_up
-    (NEW.status <> 'picked_up') OR (NEW.start_date <= now())
+    (status <> 'picked_up') OR (start_date <= now())
   );
 
 comment on policy "pickup_not_before_start" on public.booking_items is
-  'Restrictive guardrail preventing pickup before start_date. Evaluates on NEW row.';
-
+  'Restrictive guardrail preventing pickup before start_date. Evaluates directly on row columns without NEW.';

--- a/supabase/migrations/20251001105739_Prevent_Early_Pickup.sql
+++ b/supabase/migrations/20251001105739_Prevent_Early_Pickup.sql
@@ -1,0 +1,20 @@
+-- Prevent setting booking_items.status = 'picked_up' before the item start_date
+-- This policy is RESTRICTIVE and combines with existing permissive org-role policies.
+-- It will block any update that attempts to set NEW.status to 'picked_up'
+-- when NEW.start_date is still in the future (relative to now()).
+
+-- Safety: drop if it exists to allow re-run
+drop policy if exists "pickup_not_before_start" on public.booking_items;
+
+create policy "pickup_not_before_start" on public.booking_items
+  as restrictive
+  for update to authenticated
+  using (true)
+  with check (
+    -- Allow all updates except when setting status to picked_up
+    (NEW.status <> 'picked_up') OR (NEW.start_date <= now())
+  );
+
+comment on policy "pickup_not_before_start" on public.booking_items is
+  'Restrictive guardrail preventing pickup before start_date. Evaluates on NEW row.';
+


### PR DESCRIPTION
# CON2 413 - Add self pickup date validation for the user

#### Pickup Validation

- Added pickup validation to front/back and supabase to not allow you to pickup before the start date has started
- Added location_id to all parts of the pickup flow to validate better.

#### Supabase

- Updated Supabase npm package
**Backend validation and guardrails:**

* Added validation in `BookingController` and `BookingService` to require a non-empty `location_id` for pickup requests and to prevent pickup of items before their `start_date`. Bulk pickup now checks that all selected items belong to the same location and are eligible for pickup. [[1]](diffhunk://#diff-bae9dbb27af68c78ceb7e81bfd3f0f8632982686bbf5358b919d24fe7cc47814R442-R451) [[2]](diffhunk://#diff-df275c7b4845761f5c4412d0541d9ef4bcf988008c702d1f0a93cce57d9a148eR1620-R1669)

* Introduced a restrictive Supabase row-level security policy (`pickup_not_before_start`) to block updates that attempt to set `status = 'picked_up'` before the item’s `start_date`.

**Frontend logic and user feedback:**

* Updated pickup button logic in `BookingPickupButton.tsx` and booking details pages to disable the pickup action if items are from multiple locations or have a future start date, and to show appropriate error reasons to the user. [[1]](diffhunk://#diff-c40f41a54a97737b053fab32b95a6065d7171431039b996a92350a63ee820956L13-R17) [[2]](diffhunk://#diff-c40f41a54a97737b053fab32b95a6065d7171431039b996a92350a63ee820956R30) [[3]](diffhunk://#diff-c40f41a54a97737b053fab32b95a6065d7171431039b996a92350a63ee820956R67-R76) [[4]](diffhunk://#diff-8d0c1581878c72d9a68092449d5e91366a083fbab71e62f4587c3765b4eabdabR139-R177) [[5]](diffhunk://#diff-8d0c1581878c72d9a68092449d5e91366a083fbab71e62f4587c3765b4eabdabR903-R905) [[6]](diffhunk://#diff-2611b7ff67c8a465cdd64a0c1acfff5fda9b4a5e0eda520a1eb4140b07aabfeaR349-R353) [[7]](diffhunk://#diff-2611b7ff67c8a465cdd64a0c1acfff5fda9b4a5e0eda520a1eb4140b07aabfeaR364-R365)

**API and Redux updates:**

* Changed API and Redux signatures to require `location_id` for pickup actions, ensuring consistent enforcement of location-based guardrails. [[1]](diffhunk://#diff-f355613e1095bf92e2916601ca3ed0d59bac253bbe159b5004768347213bbc4dL256-R256) [[2]](diffhunk://#diff-0d170267c932ac50a35597a6877ad7c4c4bc9004fab178a9984e98005218d0f2L539-R545) [[3]](diffhunk://#diff-0d170267c932ac50a35597a6877ad7c4c4bc9004fab178a9984e98005218d0f2L1082-R1089)

**Translations and messaging:**

* Added new error messages to translations for multi-location selection and early pickup attempts, improving user guidance.

**Dependency update:**

* Updated Supabase client library to version `2.47.2` for compatibility and security.