### PR TITLE
Con2 433 fix self pickup column for non self pickup

### DIFF
--- a/frontend/src/pages/MyBookingsPage.tsx
+++ b/frontend/src/pages/MyBookingsPage.tsx
@@ -337,7 +337,7 @@ const MyBookingsPage = () => {
           return null;
         }
 
-        // Find the corresponding organization and location from extendedBooking
+        // find the corresponding org and location from extendedBooking
         const org = extendedBooking?.orgs?.find(
           (o) => o.id === item.provider_organization_id,
         );

--- a/frontend/src/pages/MyBookingsPage.tsx
+++ b/frontend/src/pages/MyBookingsPage.tsx
@@ -327,14 +327,13 @@ const MyBookingsPage = () => {
     },
     {
       accessorKey: "self_pickup",
-      header:
-        booking?.status !== "confirmed"
-          ? ""
-          : t.myBookingsPage.columns.selfPickup[lang],
+      header: booking?.booking_items?.some((item) => item.self_pickup)
+        ? t.myBookingsPage.columns.selfPickup[lang]
+        : "",
       cell: ({ row }) => {
         const item = row.original;
 
-        if (booking?.status === "pending" || !item.self_pickup) {
+        if (!item.self_pickup) {
           return null;
         }
 


### PR DESCRIPTION
Self Pickup column should not be displayed if the booking has no items that have been marked available for self-pickup OR when the items have not been confirmed