### PR TITLE
refactor add to cart button. Make it update cart state instead

### DIFF
--- a/frontend/src/components/Items/ItemCard.tsx
+++ b/frontend/src/components/Items/ItemCard.tsx
@@ -229,7 +229,8 @@ const ItemCard: React.FC<ItemsCardProps> = ({ item, preview = false }) => {
     quantity > availabilityInfo.availableQuantity ||
     quantity <= 0 ||
     !isItemAvailableForTimeframe ||
-    availabilityInfo.isChecking;
+    availabilityInfo.isChecking ||
+    (existingCartItem && existingCartItem.quantity === quantity);
 
   return (
     <Card
@@ -442,8 +443,12 @@ const ItemCard: React.FC<ItemsCardProps> = ({ item, preview = false }) => {
             <TooltipContent>
               {!startDate || !endDate ? (
                 <p>{t.itemCard.selectDatesFirst[lang]}</p>
+              ) : quantity <= 0 ? (
+                <p>{t.itemCard.selectValidQuantity[lang]}</p>
+              ) : existingCartItem && existingCartItem.quantity === quantity ? (
+                <p>{t.itemCard.quantityUnchanged[lang]}</p>
               ) : (
-                <p>{t.itemCard.selectValidQuantity[lang]} </p>
+                <p>{t.itemCard.selectValidQuantity[lang]}</p>
               )}
             </TooltipContent>
           )}

--- a/frontend/src/translations/modules/itemCard.ts
+++ b/frontend/src/translations/modules/itemCard.ts
@@ -57,4 +57,12 @@ export const itemCard = {
       },
     },
   },
+  updateQuantity: {
+    fi: "Päivitä määrä",
+    en: "Update Quantity",
+  },
+  updatedInCart: {
+    fi: "päivitetty koriin",
+    en: "updated in cart",
+  },
 };

--- a/frontend/src/translations/modules/itemCard.ts
+++ b/frontend/src/translations/modules/itemCard.ts
@@ -31,6 +31,10 @@ export const itemCard = {
     fi: "Valitse kelvollinen määrä",
     en: "Please select valid quantity",
   },
+  quantityUnchanged: {
+    fi: "Määrä on jo päivitetty",
+    en: "Quantity is already updated",
+  },
   notAvailable: {
     fi: "Ei saatavilla valitulle ajanjaksolle",
     en: "Not available for selected period",


### PR DESCRIPTION
This pull request updates the item cart functionality in the `ItemCard` component to support updating the quantity of items already in the cart, rather than only adding new items. It also improves user feedback by showing different button labels and toast messages depending on whether the item is being added or updated.

**Cart update logic and UI improvements:**

* The `ItemCard` component now checks if the item is already in the cart and sets the initial quantity accordingly. When the user clicks the button, it updates the quantity if the item exists, or adds it if not. [[1]](diffhunk://#diff-a678b6cc5a16e8e107be0646300c2f8a6ea63795c1970a30f72ae45e749bcd36L44-R49) [[2]](diffhunk://#diff-a678b6cc5a16e8e107be0646300c2f8a6ea63795c1970a30f72ae45e749bcd36L146-R174)
* The button label changes dynamically: it shows "Update Quantity" if the item is already in the cart, otherwise "Add to Cart".
* Toast messages are updated to inform the user whether the item was added or its quantity was updated in the cart. [[1]](diffhunk://#diff-a678b6cc5a16e8e107be0646300c2f8a6ea63795c1970a30f72ae45e749bcd36L146-R174) [[2]](diffhunk://#diff-a678b6cc5a16e8e107be0646300c2f8a6ea63795c1970a30f72ae45e749bcd36L170-R186)