### PR TITLE
update toast styling

### DIFF
--- a/frontend/src/components/ui/toastConfirm.tsx
+++ b/frontend/src/components/ui/toastConfirm.tsx
@@ -21,7 +21,10 @@ export const toastConfirm = ({
 }: ToastConfirmOptions) => {
   toast.custom((t) => (
     <div onMouseDown={(e) => e.stopPropagation()} data-cy="toast-confirm-root">
-      <Card className="w-[360px] shadow-lg border" data-cy="toast-confirm-card">
+      <Card
+        className="toast-confirm-card w-[360px]"
+        data-cy="toast-confirm-card"
+      >
         <CardHeader>
           <CardTitle
             className="text-lg"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -226,25 +226,27 @@
 }
 
 /* Custom Toast Styling */
-.custom-toast {
+li:has(.custom-toast) {
   position: relative;
   overflow: hidden;
 
   border-radius: 0.75rem;
   z-index: 1;
-  overflow: visible !important;
+  overflow: hidden;
 
+  /* 
+  ***** Make progressbar disappear on hover *****
   &:is(:hover, [data-expanded-true])::after {
     visibility: hidden !important;
-  }
+  } */
 }
 
 .custom-toast::after {
   content: "";
   position: absolute;
   border-radius: 0.75rem;
-  bottom: 0 !important;
-  left: 0;
+  bottom: -1px !important;
+  left: -0.5px;
   height: 4px !important;
   width: 0;
   background-color: #4caf50;
@@ -252,6 +254,19 @@
   animation-play-state: running;
   z-index: 0;
   transition: visibility 0s;
+  border-bottom-left-radius: 130px;
+  border-bottom-right-radius: 110px;
+}
+
+.custom-toast:has(.toast-confirm-card) {
+  border-radius: 14px;
+  overflow: hidden !important;
+  --tw-shadow:
+    0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)),
+    0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+  box-shadow:
+    var(--tw-inset-shadow), var(--tw-inset-ring-shadow),
+    var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
 }
 
 /* Use the :hover state to pause animation */
@@ -259,11 +274,27 @@
   animation-play-state: paused;
 }
 
-.custom-toast[data-type="error"]::after {
-  background-color: #d32f2f;
+.custom-toast[data-type="error"] {
+  &::after,
+  button[data-action="true"] {
+    background-color: #d32f2f !important;
+  }
+}
+.custom-toast[data-type="info"] {
+  &::after,
+  button[data-action="true"] {
+    background-color: var(--info-text) !important;
+  }
+}
+.custom-toast[data-type="warning"] {
+  &::after,
+  button[data-action="true"] {
+    background-color: var(--warning-text);
+  }
 }
 
-.custom-toast:not([data-type])::after {
+.custom-toast:not([data-type])::after,
+.toast-confirm.card::after {
   background-color: var(--highlight2); /* Neutral grey */
 }
 
@@ -272,6 +303,6 @@
     width: 0%;
   }
   100% {
-    width: 100%;
+    width: 100.3%;
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -241,7 +241,8 @@ li:has(.custom-toast) {
   } */
 }
 
-.custom-toast::after {
+.custom-toast {
+  &::after {
   content: "";
   position: absolute;
   border-radius: 0.75rem;
@@ -256,6 +257,11 @@ li:has(.custom-toast) {
   transition: visibility 0s;
   border-bottom-left-radius: 130px;
   border-bottom-right-radius: 110px;
+  }
+
+  & button[data-action="true"]{
+    background-color: #4caf50 !important;
+  }
 }
 
 .custom-toast:has(.toast-confirm-card) {


### PR DESCRIPTION
Main issue with the toasts:
- Info and warning toasts showed a green progressbar
- Progressbar would disappear on hover (?)
- Progressbar would spill out of it's container
- Action buttons were black by default, which didn't match the rest of the toast. Now they match the theme (blue for info, orange for warning, etc)

Let me know your thoughts

### screenshots
<img width="409" height="281" alt="Skärmbild 2025-10-02 192523" src="https://github.com/user-attachments/assets/30dd8968-03a6-42bd-971b-356ae13f760c" />
<img width="404" height="197" alt="Skärmbild 2025-10-02 193228" src="https://github.com/user-attachments/assets/7bd23092-5239-4da2-bfb0-d99dd5a87126" />
<img width="407" height="255" alt="Skärmbild 2025-10-02 195556" src="https://github.com/user-attachments/assets/b80b84dc-4712-4dc7-be4c-d0285e4aaa3d" />
