### PR TITLE
always scroll up on path change

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,13 +2,23 @@ import Navigation from "./components/Navigation";
 import { Toaster } from "sonner";
 import { UserProfileLoader } from "./context/UserProfileLoader";
 import Footer from "./components/Footer";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import { AuthProvider } from "./context/AuthProvider";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
-import { ReactNode } from "react";
+import { ReactNode, useEffect } from "react";
 
 type App = {
   children?: ReactNode;
+};
+
+const ScrollToTop: React.FC = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
 };
 
 function App({ children }: App) {
@@ -22,6 +32,8 @@ function App({ children }: App) {
       >
         <div className="min-h-screen flex flex-col text-primary">
           <UserProfileLoader />
+          {/* ScrollToTop ensures the page scrolls to the top on route change */}
+          <ScrollToTop />
           <Navigation />
           <main className="flex-1">
             {children}


### PR DESCRIPTION
This pull request introduces an improvement to the user experience by ensuring the page automatically scrolls to the top whenever the route changes in the application. This prevents users from landing in the middle of a page after navigation.

User experience enhancement:

* Added a new `ScrollToTop` component in `App.tsx` that uses `useLocation` and `useEffect` to scroll the window to the top on every route change. (`frontend/src/App.tsx`)
* Integrated the `ScrollToTop` component into the main app layout so it runs on every route change. (`frontend/src/App.tsx`)