### PR TITLE
Con2 455 fix image loading timeout issue

### DIFF
--- a/frontend/src/components/Items/ItemCard.tsx
+++ b/frontend/src/components/Items/ItemCard.tsx
@@ -96,36 +96,7 @@ const ItemCard: React.FC<ItemsCardProps> = ({ item, preview = false }) => {
 
   // Set the image URL just once when it changes
   useEffect(() => {
-    const { image_url } = stableImage;
-    if (image_url && !failedImageUrlsRef.current.has(image_url)) {
-      // Clear any existing timeout
-      if (imageLoadingTimeoutRef.current) {
-        clearTimeout(imageLoadingTimeoutRef.current);
-      }
-
-      setCurrentImage(stableImage);
-      setIsImageLoading(true);
-      setLoadFailed(false);
-
-      // Set a timeout to prevent infinite loading
-      imageLoadingTimeoutRef.current = setTimeout(() => {
-        setIsImageLoading(false);
-        failedImageUrlsRef.current.add(stableImage.image_url); // Mark as failed due to timeout
-        console.warn(`Image loading timed out for ${stableImage.image_url}`);
-      }, 5000); // 5 seconds timeout
-    } else {
-      // If no URL or URL previously failed
-      setCurrentImage(stableImage);
-      setIsImageLoading(false);
-      setLoadFailed(true);
-    }
-
-    // Cleanup function to clear timeout
-    return () => {
-      if (imageLoadingTimeoutRef.current) {
-        clearTimeout(imageLoadingTimeoutRef.current);
-      }
-    };
+    setCurrentImage(stableImage);
   }, [stableImage]);
 
   // Fetch images only once per item

--- a/frontend/src/components/Items/ItemsDetails.tsx
+++ b/frontend/src/components/Items/ItemsDetails.tsx
@@ -83,7 +83,7 @@ const ItemsDetails: React.FC = () => {
   // Get the main image - no transformation needed
   const mainImage = useMemo(() => {
     // If user selected an image, use that
-    if (selectedImageUrl) return selectedImageUrl;
+    if (selectedImageUrl) return { image_url: selectedImageUrl };
 
     // First try to find a main image
     const mainImg = itemImagesForCurrentItem.find(
@@ -92,7 +92,7 @@ const ItemsDetails: React.FC = () => {
     const firstImg = itemImagesForCurrentItem[0];
 
     // Return image URL or placeholder
-    return mainImg || firstImg || imagePlaceholder;
+    return mainImg || firstImg || { image_url: imagePlaceholder };
   }, [itemImagesForCurrentItem, selectedImageUrl]);
 
   const handleAddToCart = () => {
@@ -261,7 +261,7 @@ const ItemsDetails: React.FC = () => {
               >
                 <div className="w-[90%] max-w-[420px] max-h-[80%] h-auto border rounded-lg shadow-lg bg-white flex justify-center items-center p-2">
                   <img
-                    src={(mainImage as ItemImage).image_url}
+                    src={selectedImageUrl || (mainImage as ItemImage).image_url}
                     alt={itemContent?.item_name || "Tuotteen kuva"}
                     className="object-contain w-[400px] h-[400px] max-w-full max-h-full cursor-pointer"
                   />


### PR DESCRIPTION
In `/storage` occassionally we would get console warnings about "Image loading timeout".

This would happen even if the images did in fact load successfully. The reason being that we had duplicated timeout handling, using an effect as well as an onError function for the img element itself.

I've removed the useEffect, and kept the error handling logic for the img.


As a side fix, I've resolved the issue in the **ItemDetails** page where some images wouldn't display. This was because of the new structure for the mainImage state. It doesn't hold only a string anymore, but two properties (image_url, object_fit). I have updated the logic so the main image is the entire image object, and only the image_url is displayed.

### screenshots
<img width="510" height="253" alt="Skärmbild 2025-10-03 105218" src="https://github.com/user-attachments/assets/a520a914-3597-47ff-bde8-d69837bccd9c" />
<img width="785" height="797" alt="Skärmbild 2025-10-03 120644" src="https://github.com/user-attachments/assets/5aaaeea2-d5de-4556-aaae-27eb9743cd19" />
<img width="838" height="640" alt="Skärmbild 2025-10-03 120640" src="https://github.com/user-attachments/assets/22ba8436-7060-44f2-99d9-35321579702e" />
