### PR TITLE
CON2-457 add fallback to avatar

### DIFF
--- a/frontend/src/components/ui/UserMenu.tsx
+++ b/frontend/src/components/ui/UserMenu.tsx
@@ -29,7 +29,7 @@ import { setRedirectUrl } from "@/store/slices/uiSlice";
 import { getOrgLabel } from "@/utils/format";
 import { t } from "@/translations";
 import { SUPPORTED_LANGUAGES } from "@/translations/SUPPORTED_LANGUAGES";
-import { Avatar, AvatarFallback, AvatarImage } from "@radix-ui/react-avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "./avatar";
 
 export const UserMenu: React.FC = () => {
   const {
@@ -110,7 +110,6 @@ export const UserMenu: React.FC = () => {
         <button className="gap-3 p-1 px-2 h-fit flex items-center">
           <Avatar>
             <AvatarImage
-              className="inline h-8 w-8 rounded-full"
               src={avatarUrl}
               alt={t.userMenu.alt.userAvatar[lang]}
             />

--- a/frontend/src/components/ui/UserMenu.tsx
+++ b/frontend/src/components/ui/UserMenu.tsx
@@ -29,6 +29,7 @@ import { setRedirectUrl } from "@/store/slices/uiSlice";
 import { getOrgLabel } from "@/utils/format";
 import { t } from "@/translations";
 import { SUPPORTED_LANGUAGES } from "@/translations/SUPPORTED_LANGUAGES";
+import { Avatar, AvatarFallback, AvatarImage } from "@radix-ui/react-avatar";
 
 export const UserMenu: React.FC = () => {
   const {
@@ -107,15 +108,16 @@ export const UserMenu: React.FC = () => {
     <DropdownMenu open={open} onOpenChange={setOpen} modal={false}>
       <DropdownMenuTrigger asChild className="text-primary">
         <button className="gap-3 p-1 px-2 h-fit flex items-center">
-          {avatarUrl && avatarUrl.trim() !== "" ? (
-            <img
+          <Avatar>
+            <AvatarImage
+              className="inline h-8 w-8 rounded-full"
               src={avatarUrl}
-              className="inline h-6 w-6 rounded-full"
-              alt=""
+              alt={t.userMenu.alt.userAvatar[lang]}
             />
-          ) : (
-            <UserIcon className="inline h-6 w-6 rounded-full" />
-          )}
+            <AvatarFallback>
+              <UserIcon className="h-8 w-8 text-muted-foreground rounded-full" />
+            </AvatarFallback>
+          </Avatar>
           <div className="flex flex-col text-start font-main flex-col">
             <p className="text-md">{userName || email}</p>
             <p className="text-xs !font-[var(--main-font)]">

--- a/frontend/src/components/ui/avatar.tsx
+++ b/frontend/src/components/ui/avatar.tsx
@@ -40,7 +40,7 @@ function AvatarFallback({
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
       className={cn(
-        "bg-muted flex size-full items-center justify-center rounded-full",
+        "bg-muted text-muted-foreground flex size-full items-center justify-center rounded-full",
         className,
       )}
       {...props}

--- a/frontend/src/translations/modules/userMenu.ts
+++ b/frontend/src/translations/modules/userMenu.ts
@@ -25,4 +25,10 @@ export const userMenu = {
       fi: "Organisaation varaukset",
     },
   },
+  alt: {
+    userAvatar: {
+      en: "User Avatar",
+      fi: "Käyttäjän avatar",
+    },
+  },
 };


### PR DESCRIPTION
This pull request updates the user avatar rendering in the `UserMenu` component to use Radix UI's `Avatar` for improved accessibility and fallback handling. It also adds localized alt text for the avatar image to enhance accessibility for screen readers.

**UI Improvements:**

* Updated the `UserMenu` component to use Radix UI's `Avatar`, `AvatarImage`, and `AvatarFallback` components for displaying the user avatar, providing a consistent fallback when the avatar URL is missing. (`frontend/src/components/ui/UserMenu.tsx`) [[1]](diffhunk://#diff-080988b7fce284fcedfbf95590a43cddb3f02d6e06ea81f476331d486660b962R32) [[2]](diffhunk://#diff-080988b7fce284fcedfbf95590a43cddb3f02d6e06ea81f476331d486660b962L110-R120)

**Accessibility Enhancements:**

* Added localized alt text for the user avatar image in the translations, ensuring screen readers have appropriate descriptions in supported languages. (`frontend/src/translations/modules/userMenu.ts`)