### PR TITLE
remind users only about previously picked up items

### DIFF
--- a/backend/src/modules/reminders/reminders.service.ts
+++ b/backend/src/modules/reminders/reminders.service.ts
@@ -35,7 +35,7 @@ export class RemindersService {
     const supabase = this.supabaseService.getServiceClient();
 
     // 1) Find candidate booking_ids with items due today or overdue
-    const activeStatuses = ["confirmed", "picked_up"]; // items still out
+    const activeStatuses = ["picked_up"]; // remind users only about previously picked up items
 
     const dueTodayPromise = (async () => {
       if (scope === "overdue") return [] as string[];


### PR DESCRIPTION
This pull request makes a targeted update to the reminder logic in the `RemindersService`. The change refines which booking statuses are considered "active" for sending reminders, ensuring that users are only reminded about items they've already picked up.

* Reminders logic update:
  * In `reminders.service.ts`, the `activeStatuses` array is changed to include only `"picked_up"`, so reminders are sent exclusively for bookings where items have already been picked up, rather than both `"confirmed"` and `"picked_up"` statuses.