### PR TITLE
fix nav whitespace

### DIFF
--- a/frontend/src/components/Notifications/NotificationDesktopView.tsx
+++ b/frontend/src/components/Notifications/NotificationDesktopView.tsx
@@ -140,11 +140,7 @@ export const NotificationDesktopView: React.FC<Props> = ({
                         <Info className="h-3 w-3 text-muted-foreground" />
                       </Button>
                     </TooltipTrigger>
-                    <TooltipContent
-                      side="top"
-                      align="center"
-                      className="max-w-xs"
-                    >
+                    <TooltipContent side="top" align="center">
                       <p className="text-xs">
                         {t.navigation.notifications.tooltip?.[lang] ||
                           "Click 'All' to see and delete all notifications across all contexts"}
@@ -201,7 +197,7 @@ export const NotificationDesktopView: React.FC<Props> = ({
             {t.navigation.notifications.none[lang]}
           </p>
         ) : (
-          <ScrollArea className="h-[70vh] sm:h-[80vh]">
+          <ScrollArea className="max-h-[70vh] sm:max-h-[80vh]">
             {visibleFeed.map((n) => {
               // ———————————— Translate Title / Message ————————————
               const tpl = // Translation template for this notification type

--- a/frontend/src/components/Notifications/NotificationMobile.tsx
+++ b/frontend/src/components/Notifications/NotificationMobile.tsx
@@ -80,7 +80,7 @@ export const NotificationMobile: React.FC<Props> = ({
       </Button>
       {/* Notification Panel */}
       <Sheet open={panelOpen} onOpenChange={setPanelOpen}>
-        <SheetContent side="top" hideClose className="w-full max-w-none p-0">
+        <SheetContent side="top" hideClose className="max-w-none p-0">
           {/* Header */}
           <div className="p-3 border-b flex items-center justify-between gap-2 flex-wrap">
             {/* Notifications title (SheetTitle for accessibility) */}
@@ -97,10 +97,10 @@ export const NotificationMobile: React.FC<Props> = ({
                 {t.navigation.notifications.label[lang]}
               </SheetTitle>
               <SheetDescription className="sr-only">
-                View and manage your notifications.
+                {t.navigation.notifications.description[lang]}
               </SheetDescription>
             </div>
-            <div className="flex items-center gap-2 flex-none ml-auto">
+            <div className="flex items-center gap-2 flex-none ml-auto ">
               {showToggle && (
                 <div className="inline-flex rounded border border-(--subtle-grey) overflow-hidden">
                   {/* Active */}
@@ -135,7 +135,7 @@ export const NotificationMobile: React.FC<Props> = ({
                       <TooltipContent
                         side="bottom"
                         align="end"
-                        className="max-w-[280px] z-50"
+                        className="max-w-[280px] z-50 w-fit"
                         sideOffset={8}
                       >
                         <div className="flex flex-col gap-2">
@@ -192,11 +192,11 @@ export const NotificationMobile: React.FC<Props> = ({
           </div>
 
           {visibleFeed.length === 0 ? (
-            <p className="p-4 text-sm text-muted-foreground">
+            <p className="p-10 text-sm text-muted-foreground text-center">
               {t.navigation.notifications.none[lang]}
             </p>
           ) : (
-            <ScrollArea className="h-[70vh] sm:h-[80vh]">
+            <ScrollArea className="max-h-[70vh] sm:max-h-[80vh] overflow-y-scroll">
               {visibleFeed.map((n) => {
                 const tpl =
                   (

--- a/frontend/src/translations/modules/navigation.ts
+++ b/frontend/src/translations/modules/navigation.ts
@@ -48,6 +48,10 @@ export const navigation = {
       en: "Notifications",
       fi: "Ilmoitukset",
     },
+    description: {
+      en: "View and manage your notifications",
+      fi: "Tarkastele ja hallinnoi ilmoituksiasi",
+    },
     none: {
       en: "Nothing new yet.",
       fi: "Ei uusia ilmoituksia",


### PR DESCRIPTION
we had an excessive amount of whitespace in the notifications.
This was due to height being a fixed size instead of a maximum height.

Also added a missing translation

### screenshots
BEFORE
<img width="553" height="915" alt="Skärmbild 2025-10-08 150646" src="https://github.com/user-attachments/assets/4c4049ca-339c-442e-b8dd-4d3295c48b7d" />

AFTER - Will shrink when removing notifications
<img width="413" height="432" alt="Skärmbild 2025-10-08 154006" src="https://github.com/user-attachments/assets/1ac52b47-3c9b-4744-910c-26414c3ed2b3" />
